### PR TITLE
Add student project template view

### DIFF
--- a/backend/src/main/java/com/seniorapp/controller/ProjectTemplateController.java
+++ b/backend/src/main/java/com/seniorapp/controller/ProjectTemplateController.java
@@ -1,0 +1,26 @@
+package com.seniorapp.controller;
+
+import com.seniorapp.dto.ProjectTemplateResponse;
+import com.seniorapp.service.ProjectTemplateService;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/projects")
+@CrossOrigin(origins = "*")
+public class ProjectTemplateController {
+    private final ProjectTemplateService projectTemplateService;
+
+    public ProjectTemplateController(ProjectTemplateService projectTemplateService) {
+        this.projectTemplateService = projectTemplateService;
+    }
+
+    @GetMapping
+    public List<ProjectTemplateResponse> getAvailableTemplates() {
+        return projectTemplateService.getAvailableTemplates();
+    }
+}

--- a/backend/src/main/java/com/seniorapp/dto/ProjectTemplateResponse.java
+++ b/backend/src/main/java/com/seniorapp/dto/ProjectTemplateResponse.java
@@ -1,0 +1,49 @@
+package com.seniorapp.dto;
+
+import java.util.List;
+
+public class ProjectTemplateResponse {
+    private String projectId;
+    private String name;
+    private int sprintCount;
+    private List<String> deliverables;
+
+    public ProjectTemplateResponse(String projectId, String name, int sprintCount, List<String> deliverables) {
+        this.projectId = projectId;
+        this.name = name;
+        this.sprintCount = sprintCount;
+        this.deliverables = deliverables;
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(String projectId) {
+        this.projectId = projectId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getSprintCount() {
+        return sprintCount;
+    }
+
+    public void setSprintCount(int sprintCount) {
+        this.sprintCount = sprintCount;
+    }
+
+    public List<String> getDeliverables() {
+        return deliverables;
+    }
+
+    public void setDeliverables(List<String> deliverables) {
+        this.deliverables = deliverables;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/service/ProjectTemplateService.java
+++ b/backend/src/main/java/com/seniorapp/service/ProjectTemplateService.java
@@ -1,0 +1,33 @@
+package com.seniorapp.service;
+
+import com.seniorapp.dto.ProjectTemplateResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ProjectTemplateService {
+
+    public List<ProjectTemplateResponse> getAvailableTemplates() {
+        return List.of(
+                new ProjectTemplateResponse(
+                        "proj-se1111",
+                        "SE 1111 Graduation Project",
+                        4,
+                        List.of("Analysis", "Design", "Implementation")
+                ),
+                new ProjectTemplateResponse(
+                        "proj-da2201",
+                        "Data Analysis Project Template",
+                        3,
+                        List.of("Data Collection", "Modeling", "Final Report")
+                ),
+                new ProjectTemplateResponse(
+                        "proj-ma3302",
+                        "Mobile App Framework",
+                        5,
+                        List.of("Requirements", "UI Prototype", "App Build", "Testing")
+                )
+        );
+    }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,8 +10,6 @@ import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
 import StudentManagement from './pages/StudentManagement';
 import ResetPassword from './pages/ResetPassword';
-import StudentManagement from './pages/StudentManagement';
-import ResetPassword from './pages/ResetPassword';
 import GroupManagement from './pages/GroupManagement';
 import IntegrationSettings from './pages/IntegrationSettings';
 import CreateGroup from './pages/CreateGroup';

--- a/frontend/src/pages/CreateGroup.css
+++ b/frontend/src/pages/CreateGroup.css
@@ -1,0 +1,133 @@
+.create-group-page {
+  min-height: 80vh;
+  background: #f4f7fe;
+  padding: 32px 20px;
+}
+
+.create-group-layout {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.create-group-card,
+.template-browser {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  padding: 24px;
+}
+
+.create-group-card h2,
+.template-browser h3 {
+  margin-top: 0;
+  color: #4318ff;
+}
+
+.create-group-error {
+  color: #d92d20;
+  margin-bottom: 12px;
+  font-size: 14px;
+}
+
+.create-group-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.create-group-form label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.create-group-form input,
+.create-group-form select {
+  width: 100%;
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid #e0e5f2;
+  outline: none;
+  background: #fff;
+}
+
+.create-group-button {
+  padding: 12px;
+  cursor: pointer;
+  background: #4318ff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  margin-top: 4px;
+}
+
+.template-browser-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+  margin-bottom: 16px;
+}
+
+.template-browser-header p {
+  margin: 0;
+  color: #475467;
+}
+
+.template-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.template-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 16px;
+  background: #f8faff;
+}
+
+.template-card.selected {
+  border-color: #4318ff;
+  box-shadow: 0 0 0 1px #4318ff inset;
+}
+
+.template-card h4 {
+  margin: 0 0 10px;
+  color: #101828;
+}
+
+.template-meta {
+  margin: 0 0 10px;
+  color: #344054;
+  font-size: 14px;
+}
+
+.template-deliverables-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #344054;
+  margin-bottom: 8px;
+}
+
+.template-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #475467;
+}
+
+.template-loading,
+.template-empty {
+  color: #475467;
+}
+
+@media (max-width: 900px) {
+  .create-group-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/CreateGroup.jsx
+++ b/frontend/src/pages/CreateGroup.jsx
@@ -1,9 +1,28 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { getProjectTemplates } from '../services/api';
+import './CreateGroup.css';
 
 const CreateGroup = () => {
   const [groupName, setGroupName] = useState('');
   const [projectId, setProjectId] = useState('');
   const [error, setError] = useState('');
+  const [templates, setTemplates] = useState([]);
+  const [loadingTemplates, setLoadingTemplates] = useState(true);
+
+  useEffect(() => {
+    async function loadTemplates() {
+      try {
+        const data = await getProjectTemplates();
+        setTemplates(data);
+      } catch (err) {
+        setError(err.message || 'Failed to load project templates.');
+      } finally {
+        setLoadingTemplates(false);
+      }
+    }
+
+    loadTemplates();
+  }, []);
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -19,91 +38,80 @@ const CreateGroup = () => {
   };
 
   return (
-    <div style={{ 
-      display: 'flex', 
-      justifyContent: 'center', 
-      alignItems: 'center', 
-      minHeight: '80vh',
-      backgroundColor: '#f4f7fe' 
-    }}>
-      <div style={{ 
-        backgroundColor: 'white', 
-        padding: '30px', 
-        borderRadius: '12px', 
-        boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
-        width: '100%',
-        maxWidth: '400px'
-      }}>
-        <h2 style={{ color: '#4318FF', marginBottom: '20px', textAlign: 'center' }}>
-          Group Creation Wizard
-        </h2>
+    <div className="create-group-page">
+      <div className="create-group-layout">
+        <div className="create-group-card">
+          <h2>Group Creation Wizard</h2>
 
-        {error && (
-          <div style={{ color: 'red', marginBottom: '10px', fontSize: '14px', textAlign: 'center' }}>
-            {error}
-          </div>
-        )}
+          {error && <div className="create-group-error">{error}</div>}
 
-        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '15px' }}>
-          
-          <div>
-            <label style={{ fontWeight: '600', display: 'block', marginBottom: '5px' }}>Group Name</label>
-            <input 
-              type="text" 
-              value={groupName} 
-              onChange={(e) => setGroupName(e.target.value)} 
-              placeholder="Enter group name..."
-              required 
-              style={{ 
-                width: '100%', 
-                padding: '12px', 
-                borderRadius: '8px', 
-                border: '1px solid #E0E5F2',
-                outline: 'none'
-              }}
-            />
-          </div>
+          <form onSubmit={handleSubmit} className="create-group-form">
+            <div>
+              <label>Group Name</label>
+              <input
+                type="text"
+                value={groupName}
+                onChange={(e) => setGroupName(e.target.value)}
+                placeholder="Enter group name..."
+                required
+              />
+            </div>
 
-          <div>
-            <label style={{ fontWeight: '600', display: 'block', marginBottom: '5px' }}>Project Template</label>
-            <select 
-              value={projectId} 
-              onChange={(e) => setProjectId(e.target.value)} 
-              required
-              style={{ 
-                width: '100%', 
-                padding: '12px', 
-                borderRadius: '8px', 
-                border: '1px solid #E0E5F2',
-                backgroundColor: 'white'
-              }}
-            >
-              <option value="">Select a template...</option>
-              <option value="1">Software Engineering Project</option>
-              <option value="2">Data Analysis Template</option>
-              <option value="3">Mobile App Framework</option>
-            </select>
+            <div>
+              <label>Project Template</label>
+              <select
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+                required
+                disabled={loadingTemplates || templates.length === 0}
+              >
+                <option value="">Select a template...</option>
+                {templates.map((template) => (
+                  <option key={template.projectId} value={template.projectId}>
+                    {template.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <button type="submit" className="create-group-button">
+              Create Group
+            </button>
+          </form>
+        </div>
+
+        <section className="template-browser" aria-label="Available project templates">
+          <div className="template-browser-header">
+            <h3>Available Templates</h3>
+            <p>Review sprint count and deliverables before creating a group.</p>
           </div>
 
-          <button 
-            type="submit" 
-            style={{ 
-              padding: '12px', 
-              cursor: 'pointer', 
-              backgroundColor: '#4318FF', 
-              color: 'white', 
-              border: 'none', 
-              borderRadius: '8px',
-              fontWeight: 'bold',
-              marginTop: '10px',
-              transition: 'background 0.3s'
-            }}
-            onMouseOver={(e) => e.target.style.backgroundColor = '#3311CC'}
-            onMouseOut={(e) => e.target.style.backgroundColor = '#4318FF'}
-          >
-            Create Group
-          </button>
-        </form>
+          {loadingTemplates && <div className="template-loading">Loading templates...</div>}
+
+          {!loadingTemplates && templates.length === 0 && (
+            <div className="template-empty">No project templates are currently available.</div>
+          )}
+
+          {!loadingTemplates && templates.length > 0 && (
+            <div className="template-grid">
+              {templates.map((template) => (
+                <article
+                  key={template.projectId}
+                  className={`template-card${projectId === template.projectId ? ' selected' : ''}`}
+                >
+                  <h4>{template.name}</h4>
+                  <p className="template-meta">Sprint count: {template.sprintCount}</p>
+                  <div className="template-deliverables-title">Deliverables</div>
+                  <ul>
+                    {template.deliverables.map((deliverable) => (
+                      <li key={deliverable}>{deliverable}</li>
+                    ))}
+                  </ul>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
     </div>
   );

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -131,6 +131,10 @@ export function getGroup(groupId) {
   return request(`/groups/${groupId}`);
 }
 
+export function getProjectTemplates() {
+  return request('/projects');
+}
+
 export function createGroup(groupName, projectId) {
   return request('/groups', {
     method: 'POST',


### PR DESCRIPTION
Summary:

Develop a student-facing interface that allows users to browse and review available Project Templates prior to initiating the group creation process. This feature will help students understand template structure and requirements before creating a group.

Description:

Added a new API endpoint (/api/student/templates) and a corresponding frontend page (/panel/templates) that enables students to explore project templates in a structured, user-friendly format. The page provides key information about each template, including the number of sprints and expected deliverables, allowing students to make informed decisions during the group creation workflow.

Closes: #70 