### PR TITLE
feat(projects): add relational template builder and group-linked proj…

### DIFF
--- a/backend/src/main/java/com/seniorapp/controller/ProjectController.java
+++ b/backend/src/main/java/com/seniorapp/controller/ProjectController.java
@@ -1,0 +1,84 @@
+package com.seniorapp.controller;
+
+import com.seniorapp.dto.project.ProjectDtos.*;
+import com.seniorapp.entity.User;
+import com.seniorapp.service.ProjectService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/projects")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'ADMIN')")
+    public ResponseEntity<IdResponse> createProject(
+            @Valid @RequestBody CreateProjectRequest request,
+            @AuthenticationPrincipal User principal,
+            Authentication authentication
+    ) {
+        Long userId = principal != null ? principal.getId() : tryParseLong(authentication != null ? authentication.getName() : null);
+        Long projectId = projectService.createProject(request, userId);
+        return ResponseEntity.ok(new IdResponse("success", projectId));
+    }
+
+    @PostMapping("/{projectId}/group-assignment")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'ADMIN')")
+    public ResponseEntity<AssignmentResponse> assignGroup(
+            @PathVariable Long projectId,
+            @Valid @RequestBody AssignGroupRequest request,
+            @AuthenticationPrincipal User principal,
+            Authentication authentication
+    ) {
+        Long userId = principal != null ? principal.getId() : tryParseLong(authentication != null ? authentication.getName() : null);
+        return ResponseEntity.ok(projectService.assignGroup(projectId, request.getGroupId(), userId));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'ADMIN')")
+    public ResponseEntity<ProjectListResponse> listProjects(
+            @RequestParam(required = false) String term,
+            @RequestParam(required = false) Long templateId,
+            @RequestParam(required = false) Long groupId
+    ) {
+        return ResponseEntity.ok(new ProjectListResponse("success", projectService.listProjects(term, templateId, groupId)));
+    }
+
+    @GetMapping("/{projectId}")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'ADMIN')")
+    public ResponseEntity<ProjectDetailResponse> getProjectDetail(@PathVariable Long projectId) {
+        return ResponseEntity.ok(new ProjectDetailResponse("success", projectService.getProjectDetail(projectId)));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<Map<String, String>> handleNotFound(NoSuchElementException e) {
+        return ResponseEntity.status(404).body(Map.of("error", e.getMessage()));
+    }
+
+    private Long tryParseLong(String value) {
+        if (value == null) return null;
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/java/com/seniorapp/controller/ProjectTemplateController.java
+++ b/backend/src/main/java/com/seniorapp/controller/ProjectTemplateController.java
@@ -1,0 +1,76 @@
+package com.seniorapp.controller;
+
+import com.seniorapp.dto.projecttemplate.CreateProjectTemplateRequest;
+import com.seniorapp.dto.projecttemplate.ProjectTemplateResponses.ProjectTemplateDetailResponse;
+import com.seniorapp.dto.projecttemplate.ProjectTemplateResponses.ProjectTemplateListResponse;
+import com.seniorapp.dto.projecttemplate.ProjectTemplateResponses.TemplateCreatedResponse;
+import com.seniorapp.entity.User;
+import com.seniorapp.service.ProjectTemplateService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+@RestController
+@RequestMapping("/api/project-templates")
+public class ProjectTemplateController {
+
+    private final ProjectTemplateService projectTemplateService;
+
+    public ProjectTemplateController(ProjectTemplateService projectTemplateService) {
+        this.projectTemplateService = projectTemplateService;
+    }
+
+    @PostMapping
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'ADMIN')")
+    public ResponseEntity<TemplateCreatedResponse> createProjectTemplate(
+            @Valid @RequestBody CreateProjectTemplateRequest request,
+            @AuthenticationPrincipal User principal,
+            Authentication authentication) {
+        Long createdByUserId = principal != null ? principal.getId() : tryParseLong(authentication != null ? authentication.getName() : null);
+        Long templateId = projectTemplateService.createTemplate(request, createdByUserId);
+        return ResponseEntity.ok(
+                new TemplateCreatedResponse("success", "Project template created successfully.", templateId)
+        );
+    }
+
+    private Long tryParseLong(String value) {
+        if (value == null) return null;
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    @GetMapping
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'ADMIN')")
+    public ResponseEntity<ProjectTemplateListResponse> listProjectTemplates() {
+        return ResponseEntity.ok(
+                new ProjectTemplateListResponse("success", projectTemplateService.listTemplates())
+        );
+    }
+
+    @GetMapping("/{templateId}")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'ADMIN')")
+    public ResponseEntity<ProjectTemplateDetailResponse> getProjectTemplate(@PathVariable Long templateId) {
+        return ResponseEntity.ok(
+                new ProjectTemplateDetailResponse("success", projectTemplateService.getTemplate(templateId))
+        );
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleValidation(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<Map<String, String>> handleNotFound(NoSuchElementException e) {
+        return ResponseEntity.status(404).body(Map.of("error", e.getMessage()));
+    }
+}

--- a/backend/src/main/java/com/seniorapp/dto/project/ProjectDtos.java
+++ b/backend/src/main/java/com/seniorapp/dto/project/ProjectDtos.java
@@ -1,0 +1,503 @@
+package com.seniorapp.dto.project;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public final class ProjectDtos {
+
+    private ProjectDtos() {
+    }
+
+    public static class CreateProjectRequest {
+        private Long templateId;
+        private String title;
+        private String term;
+        private Long groupId;
+
+        public Long getTemplateId() {
+            return templateId;
+        }
+
+        public void setTemplateId(Long templateId) {
+            this.templateId = templateId;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getTerm() {
+            return term;
+        }
+
+        public void setTerm(String term) {
+            this.term = term;
+        }
+
+        public Long getGroupId() {
+            return groupId;
+        }
+
+        public void setGroupId(Long groupId) {
+            this.groupId = groupId;
+        }
+    }
+
+    public static class AssignGroupRequest {
+        private Long groupId;
+
+        public Long getGroupId() {
+            return groupId;
+        }
+
+        public void setGroupId(Long groupId) {
+            this.groupId = groupId;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class IdResponse {
+        private String status;
+        private Data data;
+
+        public IdResponse(String status, Long projectId) {
+            this.status = status;
+            this.data = new Data(projectId);
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public Data getData() {
+            return data;
+        }
+
+        public static class Data {
+            private Long projectId;
+
+            public Data(Long projectId) {
+                this.projectId = projectId;
+            }
+
+            public Long getProjectId() {
+                return projectId;
+            }
+        }
+    }
+
+    public static class AssignmentResponse {
+        private String status;
+        private Long projectId;
+        private Long groupId;
+        private LocalDateTime assignedAt;
+
+        public AssignmentResponse(String status, Long projectId, Long groupId, LocalDateTime assignedAt) {
+            this.status = status;
+            this.projectId = projectId;
+            this.groupId = groupId;
+            this.assignedAt = assignedAt;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public Long getProjectId() {
+            return projectId;
+        }
+
+        public Long getGroupId() {
+            return groupId;
+        }
+
+        public LocalDateTime getAssignedAt() {
+            return assignedAt;
+        }
+    }
+
+    public static class ProjectListResponse {
+        private String status;
+        private List<ProjectSummary> data;
+
+        public ProjectListResponse(String status, List<ProjectSummary> data) {
+            this.status = status;
+            this.data = data;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public List<ProjectSummary> getData() {
+            return data;
+        }
+    }
+
+    public static class ProjectDetailResponse {
+        private String status;
+        private ProjectDetail data;
+
+        public ProjectDetailResponse(String status, ProjectDetail data) {
+            this.status = status;
+            this.data = data;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public ProjectDetail getData() {
+            return data;
+        }
+    }
+
+    public static class ProjectSummary {
+        private Long projectId;
+        private Long templateId;
+        private String title;
+        private String term;
+        private String status;
+        private Long activeGroupId;
+        private LocalDateTime createdAt;
+
+        public Long getProjectId() {
+            return projectId;
+        }
+
+        public void setProjectId(Long projectId) {
+            this.projectId = projectId;
+        }
+
+        public Long getTemplateId() {
+            return templateId;
+        }
+
+        public void setTemplateId(Long templateId) {
+            this.templateId = templateId;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getTerm() {
+            return term;
+        }
+
+        public void setTerm(String term) {
+            this.term = term;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public Long getActiveGroupId() {
+            return activeGroupId;
+        }
+
+        public void setActiveGroupId(Long activeGroupId) {
+            this.activeGroupId = activeGroupId;
+        }
+
+        public LocalDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        public void setCreatedAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+        }
+    }
+
+    public static class ProjectDetail {
+        private Long projectId;
+        private Long templateId;
+        private String title;
+        private String term;
+        private String status;
+        private Long createdByUserId;
+        private Long activeGroupId;
+        private List<SprintDto> sprints;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public Long getProjectId() {
+            return projectId;
+        }
+
+        public void setProjectId(Long projectId) {
+            this.projectId = projectId;
+        }
+
+        public Long getTemplateId() {
+            return templateId;
+        }
+
+        public void setTemplateId(Long templateId) {
+            this.templateId = templateId;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getTerm() {
+            return term;
+        }
+
+        public void setTerm(String term) {
+            this.term = term;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public void setStatus(String status) {
+            this.status = status;
+        }
+
+        public Long getCreatedByUserId() {
+            return createdByUserId;
+        }
+
+        public void setCreatedByUserId(Long createdByUserId) {
+            this.createdByUserId = createdByUserId;
+        }
+
+        public Long getActiveGroupId() {
+            return activeGroupId;
+        }
+
+        public void setActiveGroupId(Long activeGroupId) {
+            this.activeGroupId = activeGroupId;
+        }
+
+        public List<SprintDto> getSprints() {
+            return sprints;
+        }
+
+        public void setSprints(List<SprintDto> sprints) {
+            this.sprints = sprints;
+        }
+
+        public LocalDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        public void setCreatedAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+        }
+
+        public LocalDateTime getUpdatedAt() {
+            return updatedAt;
+        }
+
+        public void setUpdatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+        }
+    }
+
+    public static class SprintDto {
+        private Integer sprintNo;
+        private String title;
+        private LocalDate startDate;
+        private LocalDate endDate;
+        private List<DeliverableDto> deliverables;
+        private List<EvaluationDto> evaluations;
+
+        public Integer getSprintNo() {
+            return sprintNo;
+        }
+
+        public void setSprintNo(Integer sprintNo) {
+            this.sprintNo = sprintNo;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public LocalDate getStartDate() {
+            return startDate;
+        }
+
+        public void setStartDate(LocalDate startDate) {
+            this.startDate = startDate;
+        }
+
+        public LocalDate getEndDate() {
+            return endDate;
+        }
+
+        public void setEndDate(LocalDate endDate) {
+            this.endDate = endDate;
+        }
+
+        public List<DeliverableDto> getDeliverables() {
+            return deliverables;
+        }
+
+        public void setDeliverables(List<DeliverableDto> deliverables) {
+            this.deliverables = deliverables;
+        }
+
+        public List<EvaluationDto> getEvaluations() {
+            return evaluations;
+        }
+
+        public void setEvaluations(List<EvaluationDto> evaluations) {
+            this.evaluations = evaluations;
+        }
+    }
+
+    public static class DeliverableDto {
+        private String type;
+        private String title;
+        private String description;
+        private Integer weight;
+        private boolean fileUploadDeliverable;
+        private boolean autoAddToAllSprints;
+        private List<RubricDto> rubrics;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public Integer getWeight() {
+            return weight;
+        }
+
+        public void setWeight(Integer weight) {
+            this.weight = weight;
+        }
+
+        public boolean isFileUploadDeliverable() {
+            return fileUploadDeliverable;
+        }
+
+        public void setFileUploadDeliverable(boolean fileUploadDeliverable) {
+            this.fileUploadDeliverable = fileUploadDeliverable;
+        }
+
+        public boolean isAutoAddToAllSprints() {
+            return autoAddToAllSprints;
+        }
+
+        public void setAutoAddToAllSprints(boolean autoAddToAllSprints) {
+            this.autoAddToAllSprints = autoAddToAllSprints;
+        }
+
+        public List<RubricDto> getRubrics() {
+            return rubrics;
+        }
+
+        public void setRubrics(List<RubricDto> rubrics) {
+            this.rubrics = rubrics;
+        }
+    }
+
+    public static class EvaluationDto {
+        private String title;
+        private Integer weight;
+        private boolean autoAddToAllSprints;
+        private List<RubricDto> rubrics;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public Integer getWeight() {
+            return weight;
+        }
+
+        public void setWeight(Integer weight) {
+            this.weight = weight;
+        }
+
+        public boolean isAutoAddToAllSprints() {
+            return autoAddToAllSprints;
+        }
+
+        public void setAutoAddToAllSprints(boolean autoAddToAllSprints) {
+            this.autoAddToAllSprints = autoAddToAllSprints;
+        }
+
+        public List<RubricDto> getRubrics() {
+            return rubrics;
+        }
+
+        public void setRubrics(List<RubricDto> rubrics) {
+            this.rubrics = rubrics;
+        }
+    }
+
+    public static class RubricDto {
+        private String title;
+        private String criteriaType;
+
+        public String getTitle() {
+            return title;
+        }
+
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
+        public String getCriteriaType() {
+            return criteriaType;
+        }
+
+        public void setCriteriaType(String criteriaType) {
+            this.criteriaType = criteriaType;
+        }
+    }
+}

--- a/backend/src/main/java/com/seniorapp/dto/projecttemplate/CreateProjectTemplateRequest.java
+++ b/backend/src/main/java/com/seniorapp/dto/projecttemplate/CreateProjectTemplateRequest.java
@@ -1,0 +1,67 @@
+package com.seniorapp.dto.projecttemplate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateProjectTemplateRequest {
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Size(max = 1000)
+    private String description;
+
+    @NotBlank
+    private String term;
+
+    @NotBlank
+    private String projectStartDate;
+
+    @NotNull
+    private JsonNode sprints;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTerm() {
+        return term;
+    }
+
+    public void setTerm(String term) {
+        this.term = term;
+    }
+
+    public JsonNode getSprints() {
+        return sprints;
+    }
+
+    public void setSprints(JsonNode sprints) {
+        this.sprints = sprints;
+    }
+
+    public String getProjectStartDate() {
+        return projectStartDate;
+    }
+
+    public void setProjectStartDate(String projectStartDate) {
+        this.projectStartDate = projectStartDate;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/dto/projecttemplate/ProjectTemplateResponses.java
+++ b/backend/src/main/java/com/seniorapp/dto/projecttemplate/ProjectTemplateResponses.java
@@ -1,0 +1,286 @@
+package com.seniorapp.dto.projecttemplate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public final class ProjectTemplateResponses {
+
+    private ProjectTemplateResponses() {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class TemplateCreatedResponse {
+        private String status;
+        private String message;
+        private Data data;
+
+        public TemplateCreatedResponse(String status, String message, Long templateId) {
+            this.status = status;
+            this.message = message;
+            this.data = new Data(templateId);
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public Data getData() {
+            return data;
+        }
+
+        public static class Data {
+            private Long templateId;
+
+            public Data(Long templateId) {
+                this.templateId = templateId;
+            }
+
+            public Long getTemplateId() {
+                return templateId;
+            }
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ProjectTemplateSummary {
+        private Long templateId;
+        private String name;
+        private String description;
+        private String term;
+        private Long createdByUserId;
+        private LocalDate projectStartDate;
+        private Integer version;
+        private boolean active;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public Long getTemplateId() {
+            return templateId;
+        }
+
+        public void setTemplateId(Long templateId) {
+            this.templateId = templateId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getTerm() {
+            return term;
+        }
+
+        public void setTerm(String term) {
+            this.term = term;
+        }
+
+        public Long getCreatedByUserId() {
+            return createdByUserId;
+        }
+
+        public void setCreatedByUserId(Long createdByUserId) {
+            this.createdByUserId = createdByUserId;
+        }
+
+        public LocalDate getProjectStartDate() {
+            return projectStartDate;
+        }
+
+        public void setProjectStartDate(LocalDate projectStartDate) {
+            this.projectStartDate = projectStartDate;
+        }
+
+        public Integer getVersion() {
+            return version;
+        }
+
+        public void setVersion(Integer version) {
+            this.version = version;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+
+        public LocalDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        public void setCreatedAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+        }
+
+        public LocalDateTime getUpdatedAt() {
+            return updatedAt;
+        }
+
+        public void setUpdatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ProjectTemplateListResponse {
+        private String status;
+        private List<ProjectTemplateSummary> data;
+
+        public ProjectTemplateListResponse(String status, List<ProjectTemplateSummary> data) {
+            this.status = status;
+            this.data = data;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public List<ProjectTemplateSummary> getData() {
+            return data;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ProjectTemplateDetail {
+        private Long templateId;
+        private String name;
+        private String description;
+        private String term;
+        private Long createdByUserId;
+        private LocalDate projectStartDate;
+        private Integer version;
+        private boolean active;
+        private JsonNode payload;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public Long getTemplateId() {
+            return templateId;
+        }
+
+        public void setTemplateId(Long templateId) {
+            this.templateId = templateId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
+        }
+
+        public String getTerm() {
+            return term;
+        }
+
+        public void setTerm(String term) {
+            this.term = term;
+        }
+
+        public Long getCreatedByUserId() {
+            return createdByUserId;
+        }
+
+        public void setCreatedByUserId(Long createdByUserId) {
+            this.createdByUserId = createdByUserId;
+        }
+
+        public LocalDate getProjectStartDate() {
+            return projectStartDate;
+        }
+
+        public void setProjectStartDate(LocalDate projectStartDate) {
+            this.projectStartDate = projectStartDate;
+        }
+
+        public Integer getVersion() {
+            return version;
+        }
+
+        public void setVersion(Integer version) {
+            this.version = version;
+        }
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public void setActive(boolean active) {
+            this.active = active;
+        }
+
+        public JsonNode getPayload() {
+            return payload;
+        }
+
+        public void setPayload(JsonNode payload) {
+            this.payload = payload;
+        }
+
+        public LocalDateTime getCreatedAt() {
+            return createdAt;
+        }
+
+        public void setCreatedAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+        }
+
+        public LocalDateTime getUpdatedAt() {
+            return updatedAt;
+        }
+
+        public void setUpdatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ProjectTemplateDetailResponse {
+        private String status;
+        private ProjectTemplateDetail data;
+
+        public ProjectTemplateDetailResponse(String status, ProjectTemplateDetail data) {
+            this.status = status;
+            this.data = data;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public ProjectTemplateDetail getData() {
+            return data;
+        }
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/Project.java
+++ b/backend/src/main/java/com/seniorapp/entity/Project.java
@@ -1,0 +1,148 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "projects")
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "template_id", nullable = false)
+    private ProjectTemplate template;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String term;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProjectStatus status = ProjectStatus.DRAFT;
+
+    @Column(nullable = false)
+    private Long createdByUserId;
+
+    @Column(name = "group_id")
+    private Long groupId;
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectSprint> sprints = new ArrayList<>();
+
+    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectGroupAssignment> assignments = new ArrayList<>();
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ProjectTemplate getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(ProjectTemplate template) {
+        this.template = template;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getTerm() {
+        return term;
+    }
+
+    public void setTerm(String term) {
+        this.term = term;
+    }
+
+    public ProjectStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ProjectStatus status) {
+        this.status = status;
+    }
+
+    public Long getCreatedByUserId() {
+        return createdByUserId;
+    }
+
+    public void setCreatedByUserId(Long createdByUserId) {
+        this.createdByUserId = createdByUserId;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Long groupId) {
+        this.groupId = groupId;
+    }
+
+    public List<ProjectSprint> getSprints() {
+        return sprints;
+    }
+
+    public void setSprints(List<ProjectSprint> sprints) {
+        this.sprints = sprints;
+    }
+
+    public List<ProjectGroupAssignment> getAssignments() {
+        return assignments;
+    }
+
+    public void setAssignments(List<ProjectGroupAssignment> assignments) {
+        this.assignments = assignments;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectDeliverable.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectDeliverable.java
@@ -1,0 +1,112 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "project_deliverables")
+public class ProjectDeliverable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_sprint_id", nullable = false)
+    private ProjectSprint sprint;
+
+    @Column(nullable = false)
+    private String type;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(length = 2000)
+    private String description;
+
+    @Column(nullable = false)
+    private Integer weight;
+
+    @Column(nullable = false)
+    private boolean fileUploadDeliverable;
+
+    @Column(nullable = false)
+    private boolean autoAddToAllSprints;
+
+    @OneToMany(mappedBy = "deliverable", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectDeliverableRubric> rubrics = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ProjectSprint getSprint() {
+        return sprint;
+    }
+
+    public void setSprint(ProjectSprint sprint) {
+        this.sprint = sprint;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+
+    public boolean isFileUploadDeliverable() {
+        return fileUploadDeliverable;
+    }
+
+    public void setFileUploadDeliverable(boolean fileUploadDeliverable) {
+        this.fileUploadDeliverable = fileUploadDeliverable;
+    }
+
+    public boolean isAutoAddToAllSprints() {
+        return autoAddToAllSprints;
+    }
+
+    public void setAutoAddToAllSprints(boolean autoAddToAllSprints) {
+        this.autoAddToAllSprints = autoAddToAllSprints;
+    }
+
+    public List<ProjectDeliverableRubric> getRubrics() {
+        return rubrics;
+    }
+
+    public void setRubrics(List<ProjectDeliverableRubric> rubrics) {
+        this.rubrics = rubrics;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectDeliverableRubric.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectDeliverableRubric.java
@@ -1,0 +1,65 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "project_deliverable_rubrics")
+public class ProjectDeliverableRubric {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_deliverable_id", nullable = false)
+    private ProjectDeliverable deliverable;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String criteriaType;
+
+    @Column(nullable = false)
+    private Integer displayOrder;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ProjectDeliverable getDeliverable() {
+        return deliverable;
+    }
+
+    public void setDeliverable(ProjectDeliverable deliverable) {
+        this.deliverable = deliverable;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getCriteriaType() {
+        return criteriaType;
+    }
+
+    public void setCriteriaType(String criteriaType) {
+        this.criteriaType = criteriaType;
+    }
+
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectEvaluation.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectEvaluation.java
@@ -1,0 +1,79 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "project_evaluations")
+public class ProjectEvaluation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_sprint_id", nullable = false)
+    private ProjectSprint sprint;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private Integer weight;
+
+    @Column(nullable = false)
+    private boolean autoAddToAllSprints;
+
+    @OneToMany(mappedBy = "evaluation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectEvaluationRubric> rubrics = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ProjectSprint getSprint() {
+        return sprint;
+    }
+
+    public void setSprint(ProjectSprint sprint) {
+        this.sprint = sprint;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+
+    public boolean isAutoAddToAllSprints() {
+        return autoAddToAllSprints;
+    }
+
+    public void setAutoAddToAllSprints(boolean autoAddToAllSprints) {
+        this.autoAddToAllSprints = autoAddToAllSprints;
+    }
+
+    public List<ProjectEvaluationRubric> getRubrics() {
+        return rubrics;
+    }
+
+    public void setRubrics(List<ProjectEvaluationRubric> rubrics) {
+        this.rubrics = rubrics;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectEvaluationRubric.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectEvaluationRubric.java
@@ -1,0 +1,65 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "project_evaluation_rubrics")
+public class ProjectEvaluationRubric {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_evaluation_id", nullable = false)
+    private ProjectEvaluation evaluation;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String criteriaType;
+
+    @Column(nullable = false)
+    private Integer displayOrder;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ProjectEvaluation getEvaluation() {
+        return evaluation;
+    }
+
+    public void setEvaluation(ProjectEvaluation evaluation) {
+        this.evaluation = evaluation;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getCriteriaType() {
+        return criteriaType;
+    }
+
+    public void setCriteriaType(String criteriaType) {
+        this.criteriaType = criteriaType;
+    }
+
+    public Integer getDisplayOrder() {
+        return displayOrder;
+    }
+
+    public void setDisplayOrder(Integer displayOrder) {
+        this.displayOrder = displayOrder;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectGroupAssignment.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectGroupAssignment.java
@@ -1,0 +1,85 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "project_group_assignments")
+public class ProjectGroupAssignment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(nullable = false)
+    private Long groupId;
+
+    @Column(nullable = false)
+    private Long assignedByUserId;
+
+    @Column(nullable = false)
+    private LocalDateTime assignedAt;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    @PrePersist
+    void onCreate() {
+        if (assignedAt == null) {
+            assignedAt = LocalDateTime.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Long groupId) {
+        this.groupId = groupId;
+    }
+
+    public Long getAssignedByUserId() {
+        return assignedByUserId;
+    }
+
+    public void setAssignedByUserId(Long assignedByUserId) {
+        this.assignedByUserId = assignedByUserId;
+    }
+
+    public LocalDateTime getAssignedAt() {
+        return assignedAt;
+    }
+
+    public void setAssignedAt(LocalDateTime assignedAt) {
+        this.assignedAt = assignedAt;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectSprint.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectSprint.java
@@ -1,0 +1,102 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "project_sprints", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"project_id", "sprint_no"})
+})
+public class ProjectSprint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    @Column(name = "sprint_no", nullable = false)
+    private Integer sprintNo;
+
+    @Column(nullable = false)
+    private String title;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @OneToMany(mappedBy = "sprint", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectDeliverable> deliverables = new ArrayList<>();
+
+    @OneToMany(mappedBy = "sprint", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ProjectEvaluation> evaluations = new ArrayList<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public void setProject(Project project) {
+        this.project = project;
+    }
+
+    public Integer getSprintNo() {
+        return sprintNo;
+    }
+
+    public void setSprintNo(Integer sprintNo) {
+        this.sprintNo = sprintNo;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public List<ProjectDeliverable> getDeliverables() {
+        return deliverables;
+    }
+
+    public void setDeliverables(List<ProjectDeliverable> deliverables) {
+        this.deliverables = deliverables;
+    }
+
+    public List<ProjectEvaluation> getEvaluations() {
+        return evaluations;
+    }
+
+    public void setEvaluations(List<ProjectEvaluation> evaluations) {
+        this.evaluations = evaluations;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectStatus.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectStatus.java
@@ -1,0 +1,7 @@
+package com.seniorapp.entity;
+
+public enum ProjectStatus {
+    DRAFT,
+    ACTIVE,
+    ARCHIVED
+}

--- a/backend/src/main/java/com/seniorapp/entity/ProjectTemplate.java
+++ b/backend/src/main/java/com/seniorapp/entity/ProjectTemplate.java
@@ -1,0 +1,157 @@
+package com.seniorapp.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "project_templates")
+public class ProjectTemplate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false, length = 1000)
+    private String description;
+
+    @Column(nullable = false)
+    private String term;
+
+    @Column(nullable = false)
+    private String createdBy;
+
+    @Column(nullable = false)
+    private Long createdByUserId;
+
+    @Column
+    private LocalDate projectStartDate;
+
+    @Column(nullable = false)
+    private Integer version = 1;
+
+    @Column(nullable = false)
+    private boolean active = true;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    private String templateJson;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getTerm() {
+        return term;
+    }
+
+    public void setTerm(String term) {
+        this.term = term;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public Long getCreatedByUserId() {
+        return createdByUserId;
+    }
+
+    public void setCreatedByUserId(Long createdByUserId) {
+        this.createdByUserId = createdByUserId;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public LocalDate getProjectStartDate() {
+        return projectStartDate;
+    }
+
+    public void setProjectStartDate(LocalDate projectStartDate) {
+        this.projectStartDate = projectStartDate;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public String getTemplateJson() {
+        return templateJson;
+    }
+
+    public void setTemplateJson(String templateJson) {
+        this.templateJson = templateJson;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/repository/ProjectGroupAssignmentRepository.java
+++ b/backend/src/main/java/com/seniorapp/repository/ProjectGroupAssignmentRepository.java
@@ -1,0 +1,10 @@
+package com.seniorapp.repository;
+
+import com.seniorapp.entity.ProjectGroupAssignment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProjectGroupAssignmentRepository extends JpaRepository<ProjectGroupAssignment, Long> {
+    Optional<ProjectGroupAssignment> findByProjectIdAndActiveTrue(Long projectId);
+}

--- a/backend/src/main/java/com/seniorapp/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/seniorapp/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package com.seniorapp.repository;
+
+import com.seniorapp.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/backend/src/main/java/com/seniorapp/repository/ProjectTemplateRepository.java
+++ b/backend/src/main/java/com/seniorapp/repository/ProjectTemplateRepository.java
@@ -1,0 +1,7 @@
+package com.seniorapp.repository;
+
+import com.seniorapp.entity.ProjectTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProjectTemplateRepository extends JpaRepository<ProjectTemplate, Long> {
+}

--- a/backend/src/main/java/com/seniorapp/service/ProjectService.java
+++ b/backend/src/main/java/com/seniorapp/service/ProjectService.java
@@ -1,0 +1,313 @@
+package com.seniorapp.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seniorapp.dto.project.ProjectDtos.*;
+import com.seniorapp.entity.*;
+import com.seniorapp.repository.ProjectGroupAssignmentRepository;
+import com.seniorapp.repository.ProjectRepository;
+import com.seniorapp.repository.ProjectTemplateRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectTemplateRepository projectTemplateRepository;
+    private final ProjectGroupAssignmentRepository assignmentRepository;
+    private final ObjectMapper objectMapper;
+
+    public ProjectService(
+            ProjectRepository projectRepository,
+            ProjectTemplateRepository projectTemplateRepository,
+            ProjectGroupAssignmentRepository assignmentRepository,
+            ObjectMapper objectMapper
+    ) {
+        this.projectRepository = projectRepository;
+        this.projectTemplateRepository = projectTemplateRepository;
+        this.assignmentRepository = assignmentRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public Long createProject(CreateProjectRequest request, Long createdByUserId) {
+        if (createdByUserId == null) {
+            throw new IllegalArgumentException("Authenticated user id is required.");
+        }
+        if (request.getTemplateId() == null) {
+            throw new IllegalArgumentException("templateId is required.");
+        }
+        if (request.getTitle() == null || request.getTitle().isBlank()) {
+            throw new IllegalArgumentException("title is required.");
+        }
+        if (request.getTerm() == null || request.getTerm().isBlank()) {
+            throw new IllegalArgumentException("term is required.");
+        }
+
+        Long safeTemplateId = Objects.requireNonNull(request.getTemplateId(), "templateId is required.");
+        ProjectTemplate template = projectTemplateRepository.findById(safeTemplateId)
+                .orElseThrow(() -> new NoSuchElementException("Project template not found: " + request.getTemplateId()));
+
+        JsonNode templateRoot;
+        try {
+            templateRoot = objectMapper.readTree(template.getTemplateJson());
+        } catch (Exception e) {
+            throw new IllegalStateException("Stored template JSON is invalid.", e);
+        }
+
+        JsonNode sprintsNode = templateRoot.get("sprints");
+        if (sprintsNode == null || !sprintsNode.isArray() || sprintsNode.isEmpty()) {
+            throw new IllegalArgumentException("Template does not include valid sprints.");
+        }
+
+        Project project = new Project();
+        project.setTemplate(template);
+        project.setTitle(request.getTitle().trim());
+        project.setTerm(request.getTerm().trim());
+        project.setStatus(ProjectStatus.DRAFT);
+        project.setCreatedByUserId(createdByUserId);
+        project.setSprints(buildProjectSprints(project, sprintsNode));
+
+        Project saved = projectRepository.save(project);
+        if (request.getGroupId() != null) {
+            assignGroup(saved.getId(), request.getGroupId(), createdByUserId);
+        }
+        return Objects.requireNonNull(saved.getId());
+    }
+
+    @Transactional
+    public AssignmentResponse assignGroup(Long projectId, Long groupId, Long assignedByUserId) {
+        if (groupId == null) {
+            throw new IllegalArgumentException("groupId is required.");
+        }
+        if (assignedByUserId == null) {
+            throw new IllegalArgumentException("Authenticated user id is required.");
+        }
+
+        Long safeProjectId = Objects.requireNonNull(projectId, "projectId is required.");
+        Project project = projectRepository.findById(safeProjectId)
+                .orElseThrow(() -> new NoSuchElementException("Project not found: " + projectId));
+
+        if (project.getGroupId() != null) {
+            throw new IllegalArgumentException("Project already has a groupId.");
+        }
+        assignmentRepository.findByProjectIdAndActiveTrue(safeProjectId).ifPresent(existing -> {
+            throw new IllegalArgumentException("Project already has an active group assignment.");
+        });
+        project.setGroupId(groupId);
+        projectRepository.save(project);
+
+        ProjectGroupAssignment assignment = new ProjectGroupAssignment();
+        assignment.setProject(project);
+        assignment.setGroupId(groupId);
+        assignment.setAssignedByUserId(assignedByUserId);
+        assignment.setAssignedAt(LocalDateTime.now());
+        assignment.setActive(true);
+        ProjectGroupAssignment saved = assignmentRepository.save(assignment);
+
+        return new AssignmentResponse("success", safeProjectId, saved.getGroupId(), saved.getAssignedAt());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectSummary> listProjects(String term, Long templateId, Long groupId) {
+        return projectRepository.findAll().stream()
+                .filter(project -> term == null || term.isBlank() || project.getTerm().equalsIgnoreCase(term.trim()))
+                .filter(project -> templateId == null || Objects.equals(project.getTemplate().getId(), templateId))
+                .filter(project -> {
+                    if (groupId == null) return true;
+                    return Objects.equals(project.getGroupId(), groupId);
+                })
+                .map(this::toSummary)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectDetail getProjectDetail(Long projectId) {
+        Long safeProjectId = Objects.requireNonNull(projectId, "projectId is required.");
+        Project project = projectRepository.findById(safeProjectId)
+                .orElseThrow(() -> new NoSuchElementException("Project not found: " + projectId));
+        return toDetail(project);
+    }
+
+    private List<ProjectSprint> buildProjectSprints(Project project, JsonNode sprintsNode) {
+        List<ProjectSprint> result = new ArrayList<>();
+        for (JsonNode sprintNode : sprintsNode) {
+            ProjectSprint sprint = new ProjectSprint();
+            sprint.setProject(project);
+            sprint.setSprintNo(sprintNode.path("sprintNo").asInt());
+            sprint.setTitle(sprintNode.path("title").asText("Sprint " + sprint.getSprintNo()));
+            sprint.setStartDate(parseDateOrNull(sprintNode.get("startDate")));
+            sprint.setEndDate(parseDateOrNull(sprintNode.get("endDate")));
+
+            sprint.setDeliverables(buildDeliverables(sprint, sprintNode.path("deliverables")));
+            sprint.setEvaluations(buildEvaluations(sprint, sprintNode.path("evaluations")));
+            result.add(sprint);
+        }
+        return result.stream()
+                .sorted(Comparator.comparing(ProjectSprint::getSprintNo))
+                .collect(Collectors.toList());
+    }
+
+    private List<ProjectDeliverable> buildDeliverables(ProjectSprint sprint, JsonNode deliverablesNode) {
+        List<ProjectDeliverable> deliverables = new ArrayList<>();
+        int index = 0;
+        for (JsonNode node : deliverablesNode) {
+            ProjectDeliverable deliverable = new ProjectDeliverable();
+            deliverable.setSprint(sprint);
+            deliverable.setType(node.path("type").asText("STATEMENT_OF_WORK"));
+            deliverable.setTitle(node.path("title").asText("Deliverable " + (index + 1)));
+            deliverable.setDescription(node.path("description").asText(""));
+            deliverable.setWeight(node.path("weight").asInt(0));
+            deliverable.setFileUploadDeliverable(node.path("fileUploadDeliverable").asBoolean(false));
+            deliverable.setAutoAddToAllSprints(node.path("autoAddToAllSprints").asBoolean(false));
+            deliverable.setRubrics(buildDeliverableRubrics(deliverable, node.path("rubrics")));
+            deliverables.add(deliverable);
+            index++;
+        }
+        return deliverables;
+    }
+
+    private List<ProjectDeliverableRubric> buildDeliverableRubrics(ProjectDeliverable deliverable, JsonNode rubricsNode) {
+        List<ProjectDeliverableRubric> rubrics = new ArrayList<>();
+        int displayOrder = 1;
+        for (JsonNode node : rubricsNode) {
+            ProjectDeliverableRubric rubric = new ProjectDeliverableRubric();
+            rubric.setDeliverable(deliverable);
+            rubric.setTitle(node.path("title").asText("Rubric " + displayOrder));
+            rubric.setCriteriaType(node.path("criteriaType").asText("SOFT").toUpperCase(Locale.ROOT));
+            rubric.setDisplayOrder(displayOrder++);
+            rubrics.add(rubric);
+        }
+        return rubrics;
+    }
+
+    private List<ProjectEvaluation> buildEvaluations(ProjectSprint sprint, JsonNode evaluationsNode) {
+        List<ProjectEvaluation> evaluations = new ArrayList<>();
+        int index = 0;
+        for (JsonNode node : evaluationsNode) {
+            ProjectEvaluation evaluation = new ProjectEvaluation();
+            evaluation.setSprint(sprint);
+            evaluation.setTitle(node.path("title").asText("Evaluation " + (index + 1)));
+            evaluation.setWeight(node.path("weight").asInt(0));
+            evaluation.setAutoAddToAllSprints(node.path("autoAddToAllSprints").asBoolean(false));
+            evaluation.setRubrics(buildEvaluationRubrics(evaluation, node.path("rubrics")));
+            evaluations.add(evaluation);
+            index++;
+        }
+        return evaluations;
+    }
+
+    private List<ProjectEvaluationRubric> buildEvaluationRubrics(ProjectEvaluation evaluation, JsonNode rubricsNode) {
+        List<ProjectEvaluationRubric> rubrics = new ArrayList<>();
+        int displayOrder = 1;
+        for (JsonNode node : rubricsNode) {
+            ProjectEvaluationRubric rubric = new ProjectEvaluationRubric();
+            rubric.setEvaluation(evaluation);
+            rubric.setTitle(node.path("title").asText("Rubric " + displayOrder));
+            rubric.setCriteriaType(node.path("criteriaType").asText("SOFT").toUpperCase(Locale.ROOT));
+            rubric.setDisplayOrder(displayOrder++);
+            rubrics.add(rubric);
+        }
+        return rubrics;
+    }
+
+    private LocalDate parseDateOrNull(JsonNode node) {
+        if (node == null || node.isNull()) return null;
+        String value = node.asText("");
+        if (value.isBlank()) return null;
+        return LocalDate.parse(value);
+    }
+
+    private ProjectSummary toSummary(Project project) {
+        ProjectSummary summary = new ProjectSummary();
+        summary.setProjectId(project.getId());
+        summary.setTemplateId(project.getTemplate().getId());
+        summary.setTitle(project.getTitle());
+        summary.setTerm(project.getTerm());
+        summary.setStatus(project.getStatus().name());
+        summary.setCreatedAt(project.getCreatedAt());
+        summary.setActiveGroupId(project.getGroupId());
+        return summary;
+    }
+
+    private ProjectDetail toDetail(Project project) {
+        ProjectDetail detail = new ProjectDetail();
+        detail.setProjectId(project.getId());
+        detail.setTemplateId(project.getTemplate().getId());
+        detail.setTitle(project.getTitle());
+        detail.setTerm(project.getTerm());
+        detail.setStatus(project.getStatus().name());
+        detail.setCreatedByUserId(project.getCreatedByUserId());
+        detail.setCreatedAt(project.getCreatedAt());
+        detail.setUpdatedAt(project.getUpdatedAt());
+        detail.setActiveGroupId(project.getGroupId());
+        detail.setSprints(project.getSprints().stream()
+                .sorted(Comparator.comparing(ProjectSprint::getSprintNo))
+                .map(this::toSprintDto)
+                .toList());
+        return detail;
+    }
+
+    private SprintDto toSprintDto(ProjectSprint sprint) {
+        SprintDto dto = new SprintDto();
+        dto.setSprintNo(sprint.getSprintNo());
+        dto.setTitle(sprint.getTitle());
+        dto.setStartDate(sprint.getStartDate());
+        dto.setEndDate(sprint.getEndDate());
+        dto.setDeliverables(sprint.getDeliverables().stream().map(this::toDeliverableDto).toList());
+        dto.setEvaluations(sprint.getEvaluations().stream().map(this::toEvaluationDto).toList());
+        return dto;
+    }
+
+    private DeliverableDto toDeliverableDto(ProjectDeliverable deliverable) {
+        DeliverableDto dto = new DeliverableDto();
+        dto.setType(deliverable.getType());
+        dto.setTitle(deliverable.getTitle());
+        dto.setDescription(deliverable.getDescription());
+        dto.setWeight(deliverable.getWeight());
+        dto.setFileUploadDeliverable(deliverable.isFileUploadDeliverable());
+        dto.setAutoAddToAllSprints(deliverable.isAutoAddToAllSprints());
+        dto.setRubrics(deliverable.getRubrics().stream()
+                .sorted(Comparator.comparing(ProjectDeliverableRubric::getDisplayOrder))
+                .map(this::toRubricDto)
+                .toList());
+        return dto;
+    }
+
+    private EvaluationDto toEvaluationDto(ProjectEvaluation evaluation) {
+        EvaluationDto dto = new EvaluationDto();
+        dto.setTitle(evaluation.getTitle());
+        dto.setWeight(evaluation.getWeight());
+        dto.setAutoAddToAllSprints(evaluation.isAutoAddToAllSprints());
+        dto.setRubrics(evaluation.getRubrics().stream()
+                .sorted(Comparator.comparing(ProjectEvaluationRubric::getDisplayOrder))
+                .map(this::toRubricDto)
+                .toList());
+        return dto;
+    }
+
+    private RubricDto toRubricDto(ProjectDeliverableRubric rubric) {
+        RubricDto dto = new RubricDto();
+        dto.setTitle(rubric.getTitle());
+        dto.setCriteriaType(rubric.getCriteriaType());
+        return dto;
+    }
+
+    private RubricDto toRubricDto(ProjectEvaluationRubric rubric) {
+        RubricDto dto = new RubricDto();
+        dto.setTitle(rubric.getTitle());
+        dto.setCriteriaType(rubric.getCriteriaType());
+        return dto;
+    }
+}

--- a/backend/src/main/java/com/seniorapp/service/ProjectTemplateService.java
+++ b/backend/src/main/java/com/seniorapp/service/ProjectTemplateService.java
@@ -1,0 +1,264 @@
+package com.seniorapp.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.seniorapp.dto.projecttemplate.CreateProjectTemplateRequest;
+import com.seniorapp.dto.projecttemplate.ProjectTemplateResponses.ProjectTemplateDetail;
+import com.seniorapp.dto.projecttemplate.ProjectTemplateResponses.ProjectTemplateSummary;
+import com.seniorapp.entity.ProjectTemplate;
+import com.seniorapp.repository.ProjectTemplateRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+public class ProjectTemplateService {
+
+    private static final Map<String, Integer> FIXED_GRADE_POINTS = Map.of(
+            "S", 100,
+            "A", 100,
+            "B", 80,
+            "C", 60,
+            "D", 50,
+            "F", 0
+    );
+
+    private final ProjectTemplateRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public ProjectTemplateService(ProjectTemplateRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public Long createTemplate(CreateProjectTemplateRequest request, Long createdByUserId) {
+        validateRequest(request);
+        if (createdByUserId == null) {
+            throw new IllegalArgumentException("Authenticated user id is required.");
+        }
+        LocalDate projectStartDate = parseProjectStartDate(request.getProjectStartDate());
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        JsonNode normalizedSprints = removeEvaluationTypeField(request.getSprints());
+        payload.put("name", request.getName());
+        payload.put("description", request.getDescription());
+        payload.put("term", request.getTerm());
+        payload.put("projectStartDate", request.getProjectStartDate());
+        payload.put("sprints", normalizedSprints);
+        payload.put("fixedGradePoints", FIXED_GRADE_POINTS);
+
+        ProjectTemplate template = new ProjectTemplate();
+        template.setName(request.getName().trim());
+        template.setDescription(request.getDescription().trim());
+        template.setTerm(request.getTerm().trim());
+        template.setCreatedBy(String.valueOf(createdByUserId));
+        template.setCreatedByUserId(createdByUserId);
+        template.setProjectStartDate(projectStartDate);
+        template.setVersion(1);
+        template.setActive(true);
+        template.setTemplateJson(serialize(payload));
+
+        return Objects.requireNonNull(repository.save(template).getId(), "Persisted template id is null.");
+    }
+
+    @Transactional(readOnly = true)
+    public List<ProjectTemplateSummary> listTemplates() {
+        return repository.findAll().stream()
+                .map(this::toSummary)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ProjectTemplateDetail getTemplate(Long templateId) {
+        Long safeTemplateId = Objects.requireNonNull(templateId, "templateId cannot be null.");
+        ProjectTemplate template = repository.findById(safeTemplateId)
+                .orElseThrow(() -> new NoSuchElementException("Project template not found: " + templateId));
+        return toDetail(template);
+    }
+
+    private void validateRequest(CreateProjectTemplateRequest request) {
+        parseProjectStartDate(request.getProjectStartDate());
+        JsonNode sprints = request.getSprints();
+        if (!sprints.isArray() || sprints.isEmpty()) {
+            throw new IllegalArgumentException("sprints must be a non-empty array.");
+        }
+
+        int projectDeliverableWeightTotal = 0;
+        for (JsonNode sprint : sprints) {
+            JsonNode sprintNo = sprint.get("sprintNo");
+            if (sprintNo == null || !sprintNo.canConvertToInt()) {
+                throw new IllegalArgumentException("Each sprint must include an integer sprintNo.");
+            }
+
+            JsonNode deliverables = sprint.get("deliverables");
+            if (deliverables == null || !deliverables.isArray()) {
+                throw new IllegalArgumentException("Each sprint must include a deliverables array.");
+            }
+
+            Set<String> deliverableTitles = new HashSet<>();
+            for (JsonNode deliverable : deliverables) {
+                String deliverableTitle = normalizeName(deliverable.get("title"));
+                if (deliverableTitle.isEmpty()) {
+                    throw new IllegalArgumentException("Deliverable title cannot be empty.");
+                }
+                if (!deliverableTitles.add(deliverableTitle)) {
+                    throw new IllegalArgumentException("Duplicate deliverable title is not allowed within a sprint.");
+                }
+                JsonNode weight = deliverable.get("weight");
+                if (weight != null && weight.isNumber() && weight.asInt() < 0) {
+                    throw new IllegalArgumentException("Deliverable weight cannot be negative.");
+                }
+                projectDeliverableWeightTotal += weight != null && weight.isNumber() ? weight.asInt() : 0;
+
+                JsonNode deliverableRubrics = deliverable.get("rubrics");
+                if (deliverableRubrics == null || !deliverableRubrics.isArray() || deliverableRubrics.isEmpty()) {
+                    throw new IllegalArgumentException("Each deliverable must include a non-empty rubrics array.");
+                }
+                Set<String> deliverableRubricTitles = new HashSet<>();
+                for (JsonNode rubric : deliverableRubrics) {
+                    String rubricTitle = normalizeName(rubric.get("title"));
+                    if (rubricTitle.isEmpty()) {
+                        throw new IllegalArgumentException("Deliverable rubric title cannot be empty.");
+                    }
+                    if (!deliverableRubricTitles.add(rubricTitle)) {
+                        throw new IllegalArgumentException("Duplicate deliverable rubric title is not allowed.");
+                    }
+                }
+            }
+
+            JsonNode sprintEvaluations = sprint.get("evaluations");
+            if (sprintEvaluations == null || !sprintEvaluations.isArray() || sprintEvaluations.isEmpty()) {
+                throw new IllegalArgumentException("Each sprint must include a non-empty evaluations array.");
+            }
+
+            Set<String> evaluationTitles = new HashSet<>();
+            int sprintEvaluationTotal = 0;
+            for (JsonNode evaluation : sprintEvaluations) {
+                String evaluationTitle = normalizeName(evaluation.get("title"));
+                if (evaluationTitle.isEmpty()) {
+                    throw new IllegalArgumentException("Evaluation title cannot be empty.");
+                }
+                if (!evaluationTitles.add(evaluationTitle)) {
+                    throw new IllegalArgumentException("Duplicate evaluation title is not allowed within a sprint.");
+                }
+                JsonNode evaluationWeight = evaluation.get("weight");
+                if (evaluationWeight != null && evaluationWeight.isNumber() && evaluationWeight.asInt() < 0) {
+                    throw new IllegalArgumentException("Evaluation weight cannot be negative.");
+                }
+                sprintEvaluationTotal += evaluationWeight != null && evaluationWeight.isNumber() ? evaluationWeight.asInt() : 0;
+                JsonNode evaluationRubrics = evaluation.get("rubrics");
+                if (evaluationRubrics == null || !evaluationRubrics.isArray() || evaluationRubrics.isEmpty()) {
+                    throw new IllegalArgumentException("Each sprint evaluation must include a non-empty rubrics array.");
+                }
+                Set<String> evaluationRubricTitles = new HashSet<>();
+                for (JsonNode rubric : evaluationRubrics) {
+                    String rubricTitle = normalizeName(rubric.get("title"));
+                    if (rubricTitle.isEmpty()) {
+                        throw new IllegalArgumentException("Evaluation rubric title cannot be empty.");
+                    }
+                    if (!evaluationRubricTitles.add(rubricTitle)) {
+                        throw new IllegalArgumentException("Duplicate evaluation rubric title is not allowed.");
+                    }
+                }
+            }
+            if (sprintEvaluationTotal != 100) {
+                throw new IllegalArgumentException("Each sprint's evaluation weights must total exactly 100.");
+            }
+        }
+        if (projectDeliverableWeightTotal != 100) {
+            throw new IllegalArgumentException("Project deliverable total weight must be exactly 100.");
+        }
+    }
+
+    private String normalizeName(JsonNode node) {
+        if (node == null || node.isNull()) return "";
+        return node.asText("").trim().toLowerCase();
+    }
+
+    private LocalDate parseProjectStartDate(String value) {
+        try {
+            return LocalDate.parse(value);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("projectStartDate must be in ISO format: YYYY-MM-DD");
+        }
+    }
+
+    private JsonNode removeEvaluationTypeField(JsonNode sprintsNode) {
+        ArrayNode clonedSprints = objectMapper.createArrayNode();
+        for (JsonNode sprintNode : sprintsNode) {
+            ObjectNode sprintCopy = sprintNode.deepCopy();
+            JsonNode evaluationsNode = sprintCopy.get("evaluations");
+            if (evaluationsNode != null && evaluationsNode.isArray()) {
+                ArrayNode normalizedEvaluations = objectMapper.createArrayNode();
+                for (JsonNode evaluationNode : evaluationsNode) {
+                    ObjectNode evaluationCopy = evaluationNode.deepCopy();
+                    evaluationCopy.remove("type");
+                    normalizedEvaluations.add(evaluationCopy);
+                }
+                sprintCopy.set("evaluations", normalizedEvaluations);
+            }
+            clonedSprints.add(sprintCopy);
+        }
+        return clonedSprints;
+    }
+
+    private ProjectTemplateSummary toSummary(ProjectTemplate template) {
+        ProjectTemplateSummary summary = new ProjectTemplateSummary();
+        summary.setTemplateId(template.getId());
+        summary.setName(template.getName());
+        summary.setDescription(template.getDescription());
+        summary.setTerm(template.getTerm());
+        summary.setCreatedByUserId(template.getCreatedByUserId());
+        summary.setProjectStartDate(template.getProjectStartDate());
+        summary.setVersion(template.getVersion());
+        summary.setActive(template.isActive());
+        summary.setCreatedAt(template.getCreatedAt());
+        summary.setUpdatedAt(template.getUpdatedAt());
+        return summary;
+    }
+
+    private ProjectTemplateDetail toDetail(ProjectTemplate template) {
+        ProjectTemplateDetail detail = new ProjectTemplateDetail();
+        detail.setTemplateId(template.getId());
+        detail.setName(template.getName());
+        detail.setDescription(template.getDescription());
+        detail.setTerm(template.getTerm());
+        detail.setCreatedByUserId(template.getCreatedByUserId());
+        detail.setProjectStartDate(template.getProjectStartDate());
+        detail.setVersion(template.getVersion());
+        detail.setActive(template.isActive());
+        detail.setPayload(deserialize(template.getTemplateJson()));
+        detail.setCreatedAt(template.getCreatedAt());
+        detail.setUpdatedAt(template.getUpdatedAt());
+        return detail;
+    }
+
+    private String serialize(Map<String, Object> payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize project template payload.", e);
+        }
+    }
+
+    private JsonNode deserialize(String payload) {
+        try {
+            return objectMapper.readTree(payload);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Stored project template payload is invalid JSON.", e);
+        }
+    }
+}

--- a/backend/src/test/java/com/seniorapp/ManualProjectCreateFromTemplate43Test.java
+++ b/backend/src/test/java/com/seniorapp/ManualProjectCreateFromTemplate43Test.java
@@ -1,0 +1,35 @@
+package com.seniorapp;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@SuppressWarnings("null")
+class ManualProjectCreateFromTemplate43Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(username = "1", roles = "COORDINATOR")
+    void createProject_fromTemplate43() throws Exception {
+        mockMvc.perform(post("/api/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"templateId": 43, "title": "Manual Project From 43", "term": "Spring 2026", "groupId": 77}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.projectId").isNumber());
+    }
+}

--- a/backend/src/test/java/com/seniorapp/ProjectApiTest.java
+++ b/backend/src/test/java/com/seniorapp/ProjectApiTest.java
@@ -1,0 +1,220 @@
+package com.seniorapp;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seniorapp.repository.ProjectRepository;
+import com.seniorapp.repository.ProjectTemplateRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@SuppressWarnings("null")
+class ProjectApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private ProjectTemplateRepository templateRepository;
+    @Autowired
+    private ProjectRepository projectRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void clearData() {
+        jdbcTemplate.execute("DELETE FROM project_deliverable_rubrics");
+        jdbcTemplate.execute("DELETE FROM project_evaluation_rubrics");
+        jdbcTemplate.execute("DELETE FROM project_deliverables");
+        jdbcTemplate.execute("DELETE FROM project_evaluations");
+        jdbcTemplate.execute("DELETE FROM project_group_assignments");
+        jdbcTemplate.execute("DELETE FROM project_sprints");
+        projectRepository.deleteAllInBatch();
+        templateRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "COORDINATOR")
+    void createProject_andDetail_andAssignGroup_happyPath() throws Exception {
+        String templatePayload = """
+                {
+                  "name": "SP Template",
+                  "description": "template",
+                  "term": "Spring 2026",
+                  "projectStartDate": "2026-02-10",
+                  "sprints": [
+                    {
+                      "sprintNo": 1,
+                      "title": "Sprint 1",
+                      "startDate": "2026-02-10",
+                      "endDate": "2026-02-20",
+                      "evaluations": [
+                        {
+                          "title": "Teamwork",
+                          "weight": 100,
+                          "rubrics": [
+                            {"title": "Participation", "criteriaType": "SOFT"}
+                          ]
+                        }
+                      ],
+                      "deliverables": [
+                        {
+                          "type": "STATEMENT_OF_WORK",
+                          "title": "SOW",
+                          "weight": 100,
+                          "rubrics": [
+                            {"title": "Quality", "criteriaType": "SOFT"}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        String templateResponse = mockMvc.perform(post("/api/project-templates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(templatePayload))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String templateId = objectMapper.readTree(templateResponse).path("data").path("templateId").asText();
+
+        String createProjectPayload = """
+                {
+                  "templateId": %s,
+                  "title": "Group 4 2026 Bitirme",
+                  "term": "Spring 2026",
+                  "groupId": 4
+                }
+                """.formatted(templateId);
+
+        String projectResponse = mockMvc.perform(post("/api/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(createProjectPayload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.projectId").isNumber())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String projectId = objectMapper.readTree(projectResponse).path("data").path("projectId").asText();
+
+        mockMvc.perform(get("/api/projects/{projectId}", projectId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("Group 4 2026 Bitirme"))
+                .andExpect(jsonPath("$.data.activeGroupId").value(4))
+                .andExpect(jsonPath("$.data.sprints[0].deliverables[0].title").value("SOW"))
+                .andExpect(jsonPath("$.data.sprints[0].evaluations[0].title").value("Teamwork"));
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "COORDINATOR")
+    void assignGroup_twice_returnsBadRequest() throws Exception {
+        String templatePayload = """
+                {
+                  "name": "SP Template",
+                  "description": "template",
+                  "term": "Spring 2026",
+                  "projectStartDate": "2026-02-10",
+                  "sprints": [
+                    {
+                      "sprintNo": 1,
+                      "evaluations": [
+                        {"title": "Eval", "weight": 100, "rubrics": [{"title": "R1", "criteriaType": "SOFT"}]}
+                      ],
+                      "deliverables": [
+                        {"type": "DEMO", "title": "Demo", "weight": 100, "rubrics": [{"title": "R2", "criteriaType": "SOFT"}]}
+                      ]
+                    }
+                  ]
+                }
+                """;
+        String templateResponse = mockMvc.perform(post("/api/project-templates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(templatePayload))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String templateId = objectMapper.readTree(templateResponse).path("data").path("templateId").asText();
+
+        String projectResponse = mockMvc.perform(post("/api/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"templateId": %s, "title": "P", "term": "Spring 2026"}
+                                """.formatted(templateId)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String projectId = objectMapper.readTree(projectResponse).path("data").path("projectId").asText();
+
+        mockMvc.perform(post("/api/projects/{projectId}/group-assignment", projectId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"groupId\": 11}"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/projects/{projectId}/group-assignment", projectId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"groupId\": 12}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "COORDINATOR")
+    void createProject_withGroupId_filtersByGroupIdInList() throws Exception {
+        String templatePayload = """
+                {
+                  "name": "SP Template",
+                  "description": "template",
+                  "term": "Spring 2026",
+                  "projectStartDate": "2026-02-10",
+                  "sprints": [
+                    {
+                      "sprintNo": 1,
+                      "evaluations": [
+                        {"title": "Eval", "weight": 100, "rubrics": [{"title": "R1", "criteriaType": "SOFT"}]}
+                      ],
+                      "deliverables": [
+                        {"type": "DEMO", "title": "Demo", "weight": 100, "rubrics": [{"title": "R2", "criteriaType": "SOFT"}]}
+                      ]
+                    }
+                  ]
+                }
+                """;
+        String templateResponse = mockMvc.perform(post("/api/project-templates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(templatePayload))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        String templateId = objectMapper.readTree(templateResponse).path("data").path("templateId").asText();
+
+        mockMvc.perform(post("/api/projects")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"templateId": %s, "title": "P1", "term": "Spring 2026", "groupId": 42}
+                                """.formatted(templateId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.projectId").isNumber());
+
+        mockMvc.perform(get("/api/projects?groupId=42"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title").value("P1"))
+                .andExpect(jsonPath("$.data[0].activeGroupId").value(42));
+    }
+}

--- a/backend/src/test/java/com/seniorapp/ProjectTemplateApiTest.java
+++ b/backend/src/test/java/com/seniorapp/ProjectTemplateApiTest.java
@@ -1,0 +1,175 @@
+package com.seniorapp;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seniorapp.repository.ProjectTemplateRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@SuppressWarnings("null")
+class ProjectTemplateApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private ProjectTemplateRepository projectTemplateRepository;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void resetTemplates() {
+        jdbcTemplate.execute("DELETE FROM project_deliverable_rubrics");
+        jdbcTemplate.execute("DELETE FROM project_evaluation_rubrics");
+        jdbcTemplate.execute("DELETE FROM project_deliverables");
+        jdbcTemplate.execute("DELETE FROM project_evaluations");
+        jdbcTemplate.execute("DELETE FROM project_group_assignments");
+        jdbcTemplate.execute("DELETE FROM project_sprints");
+        jdbcTemplate.execute("DELETE FROM projects");
+        projectTemplateRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "COORDINATOR")
+    void createTemplate_returnsSuccess() throws Exception {
+        String payload = """
+                {
+                  "name": "Senior Project 2026 Template",
+                  "description": "Default template for senior project workflow",
+                  "term": "Spring 2026",
+                  "projectStartDate": "2026-02-10",
+                  "sprints": [
+                    {
+                      "sprintNo": 1,
+                      "title": "Sprint 1",
+                      "evaluations": [
+                        {
+                          "type": "ADVISOR_EVALUATION",
+                          "title": "Sprint 1 Team Performance",
+                          "weight": 100,
+                          "rubrics": [
+                            {"title": "Scrum Participation", "criteriaType": "SOFT", "maxScore": 100}
+                          ]
+                        }
+                      ],
+                      "deliverables": [
+                        {
+                          "type": "PROPOSAL",
+                          "title": "Proposal Submission",
+                          "weight": 100,
+                          "rubrics": [
+                            {"title": "Problem Definition", "criteriaType": "SOFT", "maxScore": 100}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(post("/api/project-templates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.templateId").isNumber());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "COORDINATOR")
+    void createTemplate_withInvalidSprints_returnsBadRequest() throws Exception {
+        String payload = """
+                {
+                  "name": "Bad Template",
+                  "description": "invalid",
+                  "term": "Spring 2026",
+                  "projectStartDate": "2026-02-10",
+                  "sprints": []
+                }
+                """;
+
+        mockMvc.perform(post("/api/project-templates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "COORDINATOR")
+    void listTemplates_returnsOk() throws Exception {
+        mockMvc.perform(get("/api/project-templates").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    @WithMockUser(username = "1", roles = "COORDINATOR")
+    void detailEndpoint_returnsSavedPayload() throws Exception {
+        String payload = """
+                {
+                  "name": "Template Detail Check",
+                  "description": "detail response test",
+                  "term": "Spring 2026",
+                  "projectStartDate": "2026-02-10",
+                  "sprints": [
+                    {
+                      "sprintNo": 1,
+                      "evaluations": [
+                        {
+                          "type": "ADVISOR_EVALUATION",
+                          "title": "Sprint 1 Team Performance",
+                          "weight": 100,
+                          "rubrics": [
+                            {"title": "Scrum Participation", "criteriaType": "SOFT", "maxScore": 100}
+                          ]
+                        }
+                      ],
+                      "deliverables": [
+                        {
+                          "type": "PROPOSAL",
+                          "title": "P1",
+                          "weight": 100,
+                          "rubrics": [
+                            {"title": "Problem Definition", "criteriaType": "SOFT", "maxScore": 100}
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        String response = mockMvc.perform(post("/api/project-templates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        String templateId = objectMapper.readTree(response).path("data").path("templateId").asText();
+
+        mockMvc.perform(get("/api/project-templates/{templateId}", templateId)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("success"))
+                .andExpect(jsonPath("$.data.payload.name").value("Template Detail Check"))
+                .andExpect(jsonPath("$.data.payload.sprints[0].sprintNo").value(1));
+    }
+}

--- a/docs/full-relational-project-model.drawio
+++ b/docs/full-relational-project-model.drawio
@@ -1,0 +1,86 @@
+<mxfile host="app.diagrams.net" modified="2026-04-14T12:40:00.000Z" agent="Codex" version="24.7.17" type="device">
+  <diagram id="project-er" name="Project ER">
+    <mxGraphModel dx="1600" dy="900" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="2200" pageHeight="1400" math="0" shadow="0">
+      <root>
+        <mxCell id="0"/>
+        <mxCell id="1" parent="0"/>
+
+        <mxCell id="project_templates" value="project_templates&#xa;-----------------------------&#xa;PK id&#xa;name&#xa;description&#xa;term&#xa;created_by&#xa;created_by_user_id&#xa;project_start_date&#xa;version&#xa;active&#xa;template_json&#xa;created_at&#xa;updated_at" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="40" y="40" width="280" height="310" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="projects" value="projects&#xa;-----------------------------&#xa;PK id&#xa;FK template_id -&gt; project_templates.id&#xa;title&#xa;term&#xa;status&#xa;created_by_user_id&#xa;created_at&#xa;updated_at" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="420" y="40" width="320" height="240" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="project_sprints" value="project_sprints&#xa;-----------------------------&#xa;PK id&#xa;FK project_id -&gt; projects.id&#xa;sprint_no (unique with project_id)&#xa;title&#xa;start_date&#xa;end_date" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="840" y="40" width="320" height="220" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="project_deliverables" value="project_deliverables&#xa;-----------------------------&#xa;PK id&#xa;FK project_sprint_id -&gt; project_sprints.id&#xa;type&#xa;title&#xa;description&#xa;weight&#xa;file_upload_deliverable&#xa;auto_add_to_all_sprints" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="1260" y="20" width="360" height="260" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="project_evaluations" value="project_evaluations&#xa;-----------------------------&#xa;PK id&#xa;FK project_sprint_id -&gt; project_sprints.id&#xa;title&#xa;weight&#xa;auto_add_to_all_sprints" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="1260" y="320" width="360" height="200" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="project_deliverable_rubrics" value="project_deliverable_rubrics&#xa;-----------------------------&#xa;PK id&#xa;FK project_deliverable_id -&gt; project_deliverables.id&#xa;title&#xa;criteria_type&#xa;display_order" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="1700" y="20" width="360" height="200" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="project_evaluation_rubrics" value="project_evaluation_rubrics&#xa;-----------------------------&#xa;PK id&#xa;FK project_evaluation_id -&gt; project_evaluations.id&#xa;title&#xa;criteria_type&#xa;display_order" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="1700" y="320" width="360" height="200" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="project_group_assignments" value="project_group_assignments&#xa;-----------------------------&#xa;PK id&#xa;FK project_id -&gt; projects.id&#xa;group_id&#xa;assigned_by_user_id&#xa;assigned_at&#xa;active" style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="420" y="340" width="320" height="210" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="users" value="users&#xa;-----------------------------&#xa;PK id&#xa;email&#xa;full_name&#xa;role&#xa;status&#xa;..." style="shape=swimlane;rounded=0;whiteSpace=wrap;html=1;startSize=26;" vertex="1" parent="1">
+          <mxGeometry x="40" y="420" width="280" height="170" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_template_project" value="1:N" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" edge="1" parent="1" source="project_templates" target="projects">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_project_sprints" value="1:N" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" edge="1" parent="1" source="projects" target="project_sprints">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_sprint_deliverables" value="1:N" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" edge="1" parent="1" source="project_sprints" target="project_deliverables">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_sprint_evaluations" value="1:N" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" edge="1" parent="1" source="project_sprints" target="project_evaluations">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_deliverable_rubrics" value="1:N" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" edge="1" parent="1" source="project_deliverables" target="project_deliverable_rubrics">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_evaluation_rubrics" value="1:N" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" edge="1" parent="1" source="project_evaluations" target="project_evaluation_rubrics">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_project_assignments" value="1:N (history)" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;endArrow=block;" edge="1" parent="1" source="projects" target="project_group_assignments">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_createdby_project" value="created_by_user_id" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;endArrow=open;" edge="1" parent="1" source="users" target="projects">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_createdby_template" value="created_by_user_id" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;endArrow=open;" edge="1" parent="1" source="users" target="project_templates">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+
+        <mxCell id="edge_assignedby" value="assigned_by_user_id" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;endArrow=open;" edge="1" parent="1" source="users" target="project_group_assignments">
+          <mxGeometry relative="1" as="geometry"/>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.4",
+        "react-datepicker": "^9.1.0",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.2"
       },
@@ -55,7 +56,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -455,6 +455,59 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.19",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.19.tgz",
+      "integrity": "sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@floating-ui/utils": "^0.2.11",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -878,7 +931,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -925,7 +977,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1034,7 +1085,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1095,6 +1145,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -1165,6 +1224,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1237,7 +1306,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2185,7 +2253,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2247,9 +2314,29 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-datepicker": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-9.1.0.tgz",
+      "integrity": "sha512-lOp+m5bc+ttgtB5MHEjwiVu4nlp4CvJLS/PG1OiOe5pmg9kV73pEqO8H0Geqvg2E8gjqTaL9eRhSe+ZpeKP3nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.15",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "date-fns-tz": "^3.0.0",
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "date-fns-tz": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {
@@ -2257,7 +2344,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2435,6 +2521,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2520,7 +2612,6 @@
       "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2645,7 +2736,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "react": "^19.2.4",
+    "react-datepicker": "^9.1.0",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.2"
   },

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,6 +10,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
 import StudentManagement from './pages/StudentManagement';
 import ResetPassword from './pages/ResetPassword'; 
+import TemplateBuilder from './pages/TemplateBuilder';
 
 function App() {
   return (
@@ -33,6 +34,7 @@ function App() {
         
         {/* Koordinatör rotası */}
         <Route path="whitelist" element={<StudentManagement />} />
+        <Route path="template-builder" element={<TemplateBuilder />} />
         
         <Route
           path="users"

--- a/frontend/src/components/AppDatePicker.jsx
+++ b/frontend/src/components/AppDatePicker.jsx
@@ -1,0 +1,34 @@
+import DatePicker from 'react-datepicker';
+import 'react-datepicker/dist/react-datepicker.css';
+
+function parseIsoDate(value) {
+  if (!value) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+}
+
+function formatIsoDate(date) {
+  if (!date) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function AppDatePicker({ label, value, onChange, className = '' }) {
+  return (
+    <label className={className}>
+      {label}
+      <DatePicker
+        selected={parseIsoDate(value)}
+        onChange={(date) => onChange(formatIsoDate(date))}
+        dateFormat="yyyy-MM-dd"
+        placeholderText="YYYY-MM-DD"
+        className="app-date-picker-input"
+      />
+    </label>
+  );
+}
+
+export default AppDatePicker;

--- a/frontend/src/components/AppDateRangePicker.jsx
+++ b/frontend/src/components/AppDateRangePicker.jsx
@@ -1,0 +1,68 @@
+import DatePicker from 'react-datepicker';
+
+function parseIsoDate(value) {
+  if (!value) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+}
+
+function formatIsoDate(date) {
+  if (!date) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function formatPrettyDate(value) {
+  const date = parseIsoDate(value);
+  if (!date) return '';
+  return new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+function getRangeDays(startDate, endDate) {
+  const start = parseIsoDate(startDate);
+  const end = parseIsoDate(endDate);
+  if (!start || !end) return null;
+  const diffMs = end.getTime() - start.getTime();
+  if (diffMs < 0) return null;
+  return Math.floor(diffMs / (1000 * 60 * 60 * 24)) + 1;
+}
+
+function AppDateRangePicker({ label, startDate, endDate, onChange, className = '' }) {
+  const days = getRangeDays(startDate, endDate);
+  const displayValue = startDate && endDate
+    ? `${formatPrettyDate(startDate)} - ${formatPrettyDate(endDate)} (${days} days)`
+    : startDate
+      ? `${formatPrettyDate(startDate)} - ...`
+      : '';
+
+  return (
+    <label className={className}>
+      {label}
+      <DatePicker
+        selected={parseIsoDate(startDate)}
+        startDate={parseIsoDate(startDate)}
+        endDate={parseIsoDate(endDate)}
+        onChange={(dates) => {
+          const [start, end] = dates || [];
+          onChange(formatIsoDate(start), formatIsoDate(end));
+        }}
+        selectsRange
+        shouldCloseOnSelect
+        dateFormat="yyyy-MM-dd"
+        placeholderText="YYYY-MM-DD - YYYY-MM-DD"
+        value={displayValue}
+        readOnly
+        className="app-date-picker-input"
+      />
+    </label>
+  );
+}
+
+export default AppDateRangePicker;

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -26,12 +26,20 @@ function Layout() {
           </NavLink>
 
           {user?.role === 'COORDINATOR' && (
-            <NavLink 
-              to="/panel/whitelist" 
-              className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
-            >
-              Student Whitelist
-            </NavLink>
+            <>
+              <NavLink 
+                to="/panel/whitelist" 
+                className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
+              >
+                Student Whitelist
+              </NavLink>
+              <NavLink
+                to="/panel/template-builder"
+                className={({ isActive }) => `nav-item ${isActive ? 'active' : ''}`}
+              >
+                Template Builder
+              </NavLink>
+            </>
           )}
 
           {user?.role === 'ADMIN' && (

--- a/frontend/src/pages/TemplateBuilder.css
+++ b/frontend/src/pages/TemplateBuilder.css
@@ -1,0 +1,343 @@
+.template-builder-page {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: calc(100vh - 120px);
+}
+
+.template-builder-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.template-builder-grid {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 16px;
+  min-height: calc(100vh - 200px);
+}
+
+.template-tree,
+.template-editor {
+  background: linear-gradient(180deg, #ffffff, #fbfdff);
+  border: 1px solid #e8edf5;
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.06);
+}
+
+.template-tree-header {
+  margin-bottom: 10px;
+}
+
+.template-tree-group {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #eef1f5;
+}
+
+.template-tree-actions {
+  display: grid;
+  gap: 6px;
+  margin: 6px 0;
+}
+
+.template-subtree {
+  margin-left: 12px;
+  margin-bottom: 6px;
+}
+
+.node-row {
+  display: grid;
+  grid-template-columns: 1fr 30px;
+  gap: 6px;
+  align-items: start;
+}
+
+.template-node {
+  width: 100%;
+  text-align: left;
+  border: 1px solid #d9dfe7;
+  background: #f8fafc;
+  padding: 9px 10px;
+  border-radius: 8px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.template-node.child {
+  background: #f9fbff;
+}
+
+.template-node.leaf {
+  font-size: 13px;
+  background: #fdfefe;
+}
+
+.template-node.active {
+  border-color: #3b82f6;
+  background: #eff6ff;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+.template-form {
+  display: grid;
+  gap: 10px;
+  max-width: 820px;
+}
+
+.template-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.template-form label.checkbox-row {
+  flex-direction: row-reverse;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-height: 38px;
+  margin-top: 20px;
+  font-weight: 600;
+}
+
+.template-form label.checkbox-row input[type='checkbox'] {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  accent-color: #2563eb;
+}
+
+.template-form label.checkbox-row span {
+  line-height: 1;
+  color: #111827;
+}
+
+.template-form input,
+.template-form textarea,
+.template-form select {
+  border: 1px solid #dbe2ea;
+  border-radius: 8px;
+  padding: 8px;
+  font: inherit;
+  max-width: 100%;
+}
+
+.template-form textarea {
+  min-height: 80px;
+}
+
+.template-btn {
+  border: 1px solid #d0d7e2;
+  background: #f7f9fc;
+  border-radius: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.template-btn:hover,
+.template-node:hover {
+  border-color: #a8b5c9;
+}
+
+.template-btn.action {
+  width: 100%;
+  text-align: left;
+}
+
+.add-btn {
+  border-style: solid;
+  border-width: 1px;
+  border-color: #d0d7e2;
+  background: #f7f9fc;
+}
+
+.template-btn.small {
+  padding: 6px 8px;
+  font-size: 12px;
+}
+
+.template-btn.tiny {
+  padding: 4px 8px;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.add-sprint-bottom {
+  width: 100%;
+  margin-top: 12px;
+  position: sticky;
+  bottom: 0;
+  background: #eef4ff;
+}
+
+.add-uniform {
+  width: 100%;
+  background: #eef4ff;
+  border-color: #c7d2e5;
+  text-align: center;
+}
+
+.editor-subsection {
+  border: 1px solid #e5ecf5;
+  border-radius: 10px;
+  padding: 10px;
+  background: #f9fbff;
+}
+
+.editor-subsection-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  gap: 8px;
+}
+
+.chip-list {
+  display: grid;
+  gap: 6px;
+}
+
+.rubric-inline-list {
+  display: grid;
+  gap: 10px;
+}
+
+.rubric-inline-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(180px, 1fr) 32px;
+  gap: 8px;
+  align-items: end;
+}
+
+.rubric-inline-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.rubric-inline-row select {
+  background: #ffffff;
+}
+
+.delete-node-btn {
+  border: 1px solid #f2c2c2;
+  color: #9f1239;
+  background: #fff1f2;
+  border-radius: 8px;
+  height: 36px;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.template-editor {
+  display: flex;
+  flex-direction: column;
+}
+
+.template-form {
+  grid-template-columns: repeat(2, minmax(220px, 360px));
+  align-items: start;
+}
+
+.field-full {
+  grid-column: 1 / -1;
+}
+
+.editor-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.template-inline-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.template-status {
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+
+.template-status.is-success {
+  background: #ecfdf3;
+  color: #166534;
+}
+
+.template-status.is-error {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.type-combobox {
+  position: relative;
+}
+
+.type-combobox-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  border: 1px solid #cfd8e5;
+  border-radius: 10px;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  padding: 4px;
+}
+
+.type-combobox-item {
+  width: 100%;
+  text-align: left;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
+.type-combobox-item:hover {
+  background: #eef4ff;
+}
+
+.type-combobox-item.create {
+  border-top: 1px solid #e7edf6;
+  margin-top: 4px;
+  padding-top: 10px;
+}
+
+.react-datepicker-wrapper {
+  width: 100%;
+}
+
+.app-date-picker-input {
+  width: 100%;
+}
+
+.react-datepicker-popper {
+  z-index: 40;
+}
+
+.template-preview {
+  margin-top: 16px;
+}
+
+.template-preview pre {
+  background: #0f172a;
+  color: #e2e8f0;
+  border-radius: 8px;
+  padding: 12px;
+  max-height: 340px;
+  overflow: auto;
+  font-size: 12px;
+}

--- a/frontend/src/pages/TemplateBuilder.jsx
+++ b/frontend/src/pages/TemplateBuilder.jsx
@@ -1,0 +1,1085 @@
+import { useState } from 'react';
+import { createProjectTemplate } from '../services/api';
+import { useAuth } from '../context/AuthContext';
+import { Navigate } from 'react-router-dom';
+import AppDatePicker from '../components/AppDatePicker';
+import AppDateRangePicker from '../components/AppDateRangePicker';
+import './TemplateBuilder.css';
+
+const GRADING_TYPE_OPTIONS = ['SOFT', 'BINARY'];
+const DELIVERABLE_BASE_TYPES = ['STATEMENT_OF_WORK', 'DEMO', 'PROPOSAL'];
+
+function normalizeText(value) {
+  return (value || '').trim().toLowerCase();
+}
+
+function nextIndexedLabel(existingValues, prefix) {
+  const used = new Set(existingValues.map((value) => normalizeText(value)));
+  let index = 1;
+  let candidate = `${prefix} ${index}`;
+  while (used.has(normalizeText(candidate))) {
+    index += 1;
+    candidate = `${prefix} ${index}`;
+  }
+  return candidate;
+}
+
+function createDefaultRubric(title = 'New Rubric 1') {
+  return {
+    title,
+    criteriaType: 'SOFT',
+  };
+}
+
+function createDefaultDeliverable(title = 'New Deliverable 1') {
+  return {
+    type: DELIVERABLE_BASE_TYPES[0],
+    title,
+    description: '',
+    weight: 15,
+    autoAddToAllSprints: false,
+    autoSyncKey: null,
+    fileUploadDeliverable: false,
+    submission: {
+      allowedContentTypes: ['MARKDOWN'],
+      maxSubmissionCount: 1,
+      requiresCommitteeAssignment: false,
+    },
+    rubrics: [createDefaultRubric('New Rubric 1')],
+    evaluations: [],
+  };
+}
+
+function createDefaultSprintEvaluation(title = 'Sprint Evaluation 1') {
+  return {
+    title,
+    weight: 100,
+    autoAddToAllSprints: false,
+    autoSyncKey: null,
+    rubrics: [createDefaultRubric('New Rubric 1')],
+  };
+}
+
+function createDefaultSprint(nextNo) {
+  return {
+    sprintNo: nextNo,
+    title: `Sprint ${nextNo}`,
+    startDate: '',
+    endDate: '',
+    deliverables: [],
+    evaluations: [],
+  };
+}
+
+function deepClone(value) {
+  return structuredClone(value);
+}
+
+function parseIsoDate(value) {
+  if (!value) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  if (!year || !month || !day) return null;
+  return new Date(year, month - 1, day);
+}
+
+function formatIsoDate(date) {
+  if (!date) return '';
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function addDays(date, days) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function collectAutoAddItems(sprints, key) {
+  const seen = new Set();
+  const items = [];
+  for (const sprint of sprints) {
+    for (const item of sprint[key] || []) {
+      if (!item?.autoAddToAllSprints) continue;
+      const signature = JSON.stringify({
+        type: item.type,
+        title: item.title,
+        description: item.description,
+        weight: item.weight,
+        fileUploadDeliverable: item.fileUploadDeliverable,
+        rubrics: item.rubrics,
+        submission: item.submission,
+      });
+      if (seen.has(signature)) continue;
+      seen.add(signature);
+      const clone = deepClone(item);
+      if (!clone.autoSyncKey) clone.autoSyncKey = `auto-${key}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      items.push(clone);
+    }
+  }
+  return items;
+}
+
+function stripUiOnlyFields(template) {
+  const clean = deepClone(template);
+  clean.sprints = (clean.sprints || []).map((sprint) => ({
+    ...sprint,
+    deliverables: (sprint.deliverables || []).map(({ autoSyncKey, ...deliverable }) => deliverable),
+    evaluations: (sprint.evaluations || []).map(({ autoSyncKey, type, ...evaluation }) => evaluation),
+  }));
+  return clean;
+}
+
+function TemplateBuilder() {
+  const { user, loading } = useAuth();
+
+  const [template, setTemplate] = useState({
+    name: 'Senior Project 2026 Template',
+    description: 'Default template for senior project workflow',
+    term: 'Spring 2026',
+    projectStartDate: '',
+    sprints: [],
+  });
+  const [selected, setSelected] = useState({ type: 'template' });
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState({ type: '', message: '' });
+  const [clipboard, setClipboard] = useState({
+    deliverable: null,
+    evaluation: null,
+    rubrics: null,
+  });
+  const [typeQuery, setTypeQuery] = useState('');
+  const [showTypeMenu, setShowTypeMenu] = useState(false);
+
+  if (loading) return <div className="loading">Loading...</div>;
+  if (!user) return <Navigate to="/" replace />;
+  if (user.role !== 'COORDINATOR') return <Navigate to="/access-denied" replace />;
+
+  const updateTemplateField = (field, value) => {
+    setTemplate((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const addSprint = () => {
+    setTemplate((prev) => {
+      const nextNo = prev.sprints.length + 1;
+      const newSprint = createDefaultSprint(nextNo);
+      const previousSprint = prev.sprints[prev.sprints.length - 1];
+      const prevStart = parseIsoDate(previousSprint?.startDate);
+      const prevEnd = parseIsoDate(previousSprint?.endDate);
+      if (prevStart && prevEnd && prevEnd.getTime() >= prevStart.getTime()) {
+        const prevDurationDays = Math.floor((prevEnd.getTime() - prevStart.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+        const nextStart = addDays(prevEnd, 1);
+        const nextEnd = addDays(nextStart, prevDurationDays - 1);
+        newSprint.startDate = formatIsoDate(nextStart);
+        newSprint.endDate = formatIsoDate(nextEnd);
+      }
+      newSprint.deliverables = collectAutoAddItems(prev.sprints, 'deliverables');
+      newSprint.evaluations = collectAutoAddItems(prev.sprints, 'evaluations');
+      const next = [...prev.sprints, newSprint];
+      return { ...prev, sprints: next };
+    });
+    setSelected({ type: 'sprint', sprintIndex: template.sprints.length });
+  };
+
+  const removeSprint = (sprintIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      next.sprints.splice(sprintIndex, 1);
+      next.sprints = next.sprints.map((s, i) => ({ ...s, sprintNo: i + 1 }));
+      return next;
+    });
+    setSelected({ type: 'template' });
+  };
+
+  const addDeliverable = (sprintIndex) => {
+    const sprint = template.sprints[sprintIndex];
+    const currentTotal = (sprint?.deliverables ?? []).reduce(
+      (sum, d) => sum + (Number(d.weight) || 0),
+      0
+    );
+    if (currentTotal >= 100) {
+      setStatus({ type: 'error', message: `Sprint ${sprint.sprintNo} deliverable weight is already 100%.` });
+      return;
+    }
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const existingTitles = next.sprints[sprintIndex].deliverables.map((item) => item.title);
+      const nextTitle = nextIndexedLabel(existingTitles, 'New Deliverable');
+      next.sprints[sprintIndex].deliverables.push(createDefaultDeliverable(nextTitle));
+      return next;
+    });
+    const deliverableIndex = template.sprints[sprintIndex]?.deliverables?.length ?? 0;
+    setSelected({ type: 'deliverable', sprintIndex, deliverableIndex });
+  };
+
+  const removeDeliverable = (sprintIndex, deliverableIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      next.sprints[sprintIndex].deliverables.splice(deliverableIndex, 1);
+      return next;
+    });
+    setSelected({ type: 'sprint', sprintIndex });
+  };
+
+  const addSprintEvaluation = (sprintIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const existingTitles = next.sprints[sprintIndex].evaluations.map((item) => item.title);
+      const nextTitle = nextIndexedLabel(existingTitles, 'Sprint Evaluation');
+      next.sprints[sprintIndex].evaluations.push(createDefaultSprintEvaluation(nextTitle));
+      return next;
+    });
+    const evaluationIndex = template.sprints[sprintIndex]?.evaluations?.length ?? 0;
+    setSelected({ type: 'sprintEvaluation', sprintIndex, evaluationIndex });
+  };
+
+  const removeSprintEvaluation = (sprintIndex, evaluationIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      next.sprints[sprintIndex].evaluations.splice(evaluationIndex, 1);
+      return next;
+    });
+    setSelected({ type: 'sprint', sprintIndex });
+  };
+
+  const addDeliverableRubric = (sprintIndex, deliverableIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const targetDeliverable = next.sprints[sprintIndex].deliverables[deliverableIndex];
+      const existingTitles = targetDeliverable.rubrics.map((item) => item.title);
+      const nextTitle = nextIndexedLabel(existingTitles, 'New Rubric');
+      targetDeliverable.rubrics.push(createDefaultRubric(nextTitle));
+      if (targetDeliverable.autoAddToAllSprints && targetDeliverable.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].deliverables.length; j += 1) {
+            if (i === sprintIndex && j === deliverableIndex) continue;
+            const candidate = next.sprints[i].deliverables[j];
+            if (candidate.autoSyncKey === targetDeliverable.autoSyncKey) {
+              candidate.rubrics = deepClone(targetDeliverable.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const addSprintEvalRubric = (sprintIndex, evaluationIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const targetEvaluation = next.sprints[sprintIndex].evaluations[evaluationIndex];
+      const existingTitles = targetEvaluation.rubrics.map((item) => item.title);
+      const nextTitle = nextIndexedLabel(existingTitles, 'New Rubric');
+      targetEvaluation.rubrics.push(createDefaultRubric(nextTitle));
+      if (targetEvaluation.autoAddToAllSprints && targetEvaluation.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].evaluations.length; j += 1) {
+            if (i === sprintIndex && j === evaluationIndex) continue;
+            const candidate = next.sprints[i].evaluations[j];
+            if (candidate.autoSyncKey === targetEvaluation.autoSyncKey) {
+              candidate.rubrics = deepClone(targetEvaluation.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const pasteDeliverable = (sprintIndex) => {
+    if (!clipboard.deliverable) return;
+    setTemplate((prev) => {
+      const next = deepClone(prev);
+      next.sprints[sprintIndex].deliverables.push(deepClone(clipboard.deliverable));
+      return next;
+    });
+    const deliverableIndex = template.sprints[sprintIndex]?.deliverables?.length ?? 0;
+    setSelected({ type: 'deliverable', sprintIndex, deliverableIndex });
+  };
+
+  const pasteEvaluation = (sprintIndex) => {
+    if (!clipboard.evaluation) return;
+    setTemplate((prev) => {
+      const next = deepClone(prev);
+      next.sprints[sprintIndex].evaluations.push(deepClone(clipboard.evaluation));
+      return next;
+    });
+    const evaluationIndex = template.sprints[sprintIndex]?.evaluations?.length ?? 0;
+    setSelected({ type: 'sprintEvaluation', sprintIndex, evaluationIndex });
+  };
+
+  const pasteDeliverableRubrics = (sprintIndex, deliverableIndex) => {
+    if (!clipboard.rubrics) return;
+    setTemplate((prev) => {
+      const next = deepClone(prev);
+      const targetDeliverable = next.sprints[sprintIndex].deliverables[deliverableIndex];
+      targetDeliverable.rubrics = deepClone(clipboard.rubrics);
+      if (targetDeliverable.autoAddToAllSprints && targetDeliverable.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].deliverables.length; j += 1) {
+            if (i === sprintIndex && j === deliverableIndex) continue;
+            const candidate = next.sprints[i].deliverables[j];
+            if (candidate.autoSyncKey === targetDeliverable.autoSyncKey) {
+              candidate.rubrics = deepClone(targetDeliverable.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const pasteEvaluationRubrics = (sprintIndex, evaluationIndex) => {
+    if (!clipboard.rubrics) return;
+    setTemplate((prev) => {
+      const next = deepClone(prev);
+      const targetEvaluation = next.sprints[sprintIndex].evaluations[evaluationIndex];
+      targetEvaluation.rubrics = deepClone(clipboard.rubrics);
+      if (targetEvaluation.autoAddToAllSprints && targetEvaluation.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].evaluations.length; j += 1) {
+            if (i === sprintIndex && j === evaluationIndex) continue;
+            const candidate = next.sprints[i].evaluations[j];
+            if (candidate.autoSyncKey === targetEvaluation.autoSyncKey) {
+              candidate.rubrics = deepClone(targetEvaluation.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const updateDeliverableRubricField = (sprintIndex, deliverableIndex, rubricIndex, field, value) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const targetDeliverable = next.sprints[sprintIndex].deliverables[deliverableIndex];
+      targetDeliverable.rubrics[rubricIndex][field] = value;
+      if (targetDeliverable.autoAddToAllSprints && targetDeliverable.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].deliverables.length; j += 1) {
+            if (i === sprintIndex && j === deliverableIndex) continue;
+            const candidate = next.sprints[i].deliverables[j];
+            if (candidate.autoSyncKey === targetDeliverable.autoSyncKey) {
+              candidate.rubrics = deepClone(targetDeliverable.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const updateSprintEvaluationRubricField = (sprintIndex, evaluationIndex, rubricIndex, field, value) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const targetEvaluation = next.sprints[sprintIndex].evaluations[evaluationIndex];
+      targetEvaluation.rubrics[rubricIndex][field] = value;
+      if (targetEvaluation.autoAddToAllSprints && targetEvaluation.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].evaluations.length; j += 1) {
+            if (i === sprintIndex && j === evaluationIndex) continue;
+            const candidate = next.sprints[i].evaluations[j];
+            if (candidate.autoSyncKey === targetEvaluation.autoSyncKey) {
+              candidate.rubrics = deepClone(targetEvaluation.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const removeDeliverableRubric = (sprintIndex, deliverableIndex, rubricIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const targetDeliverable = next.sprints[sprintIndex].deliverables[deliverableIndex];
+      targetDeliverable.rubrics.splice(rubricIndex, 1);
+      if (targetDeliverable.autoAddToAllSprints && targetDeliverable.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].deliverables.length; j += 1) {
+            if (i === sprintIndex && j === deliverableIndex) continue;
+            const candidate = next.sprints[i].deliverables[j];
+            if (candidate.autoSyncKey === targetDeliverable.autoSyncKey) {
+              candidate.rubrics = deepClone(targetDeliverable.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const removeSprintEvaluationRubric = (sprintIndex, evaluationIndex, rubricIndex) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      const targetEvaluation = next.sprints[sprintIndex].evaluations[evaluationIndex];
+      targetEvaluation.rubrics.splice(rubricIndex, 1);
+      if (targetEvaluation.autoAddToAllSprints && targetEvaluation.autoSyncKey) {
+        for (let i = 0; i < next.sprints.length; i += 1) {
+          for (let j = 0; j < next.sprints[i].evaluations.length; j += 1) {
+            if (i === sprintIndex && j === evaluationIndex) continue;
+            const candidate = next.sprints[i].evaluations[j];
+            if (candidate.autoSyncKey === targetEvaluation.autoSyncKey) {
+              candidate.rubrics = deepClone(targetEvaluation.rubrics);
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const updateSelectedNode = (field, value) => {
+    setTemplate((prev) => {
+      const next = structuredClone(prev);
+      if (selected.type === 'sprint') {
+        next.sprints[selected.sprintIndex][field] = value;
+      } else if (selected.type === 'deliverable') {
+        const sprint = next.sprints[selected.sprintIndex];
+        const deliverable = sprint.deliverables[selected.deliverableIndex];
+        if (field === 'weight') {
+          const deliverables = sprint.deliverables;
+          const currentWeight = Number(deliverables[selected.deliverableIndex].weight) || 0;
+          const othersTotal = deliverables.reduce(
+            (sum, d, i) => sum + (i === selected.deliverableIndex ? 0 : Number(d.weight) || 0),
+            0
+          );
+          const requested = Number(value) || 0;
+          const bounded = Math.max(0, Math.min(requested, Math.max(0, 100 - othersTotal)));
+          deliverables[selected.deliverableIndex][field] = bounded;
+        } else if (field === 'autoAddToAllSprints') {
+          if (value) {
+            const key = deliverable.autoSyncKey || `auto-deliverables-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            deliverable.autoAddToAllSprints = true;
+            deliverable.autoSyncKey = key;
+          } else {
+            const key = deliverable.autoSyncKey;
+            if (key) {
+              for (const sprintItem of next.sprints) {
+                sprintItem.deliverables.forEach((item) => {
+                  if (item.autoSyncKey === key) {
+                    item.autoAddToAllSprints = false;
+                    item.autoSyncKey = null;
+                  }
+                });
+              }
+            } else {
+              deliverable.autoAddToAllSprints = false;
+            }
+          }
+        } else {
+          deliverable[field] = value;
+        }
+
+        if (field !== 'autoAddToAllSprints' && deliverable.autoAddToAllSprints && deliverable.autoSyncKey) {
+          for (let i = 0; i < next.sprints.length; i += 1) {
+            for (let j = 0; j < next.sprints[i].deliverables.length; j += 1) {
+              if (i === selected.sprintIndex && j === selected.deliverableIndex) continue;
+              const item = next.sprints[i].deliverables[j];
+              if (item.autoSyncKey === deliverable.autoSyncKey) {
+                item[field] = deepClone(deliverable[field]);
+              }
+            }
+          }
+        }
+      } else if (selected.type === 'sprintEvaluation') {
+        const sprint = next.sprints[selected.sprintIndex];
+        const evaluation = sprint.evaluations[selected.evaluationIndex];
+
+        if (field === 'autoAddToAllSprints') {
+          if (value) {
+            const key = evaluation.autoSyncKey || `auto-evaluations-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            evaluation.autoAddToAllSprints = true;
+            evaluation.autoSyncKey = key;
+          } else {
+            const key = evaluation.autoSyncKey;
+            if (key) {
+              for (const sprintItem of next.sprints) {
+                sprintItem.evaluations.forEach((item) => {
+                  if (item.autoSyncKey === key) {
+                    item.autoAddToAllSprints = false;
+                    item.autoSyncKey = null;
+                  }
+                });
+              }
+            } else {
+              evaluation.autoAddToAllSprints = false;
+            }
+          }
+        } else {
+          evaluation[field] = value;
+        }
+
+        if (field !== 'autoAddToAllSprints' && evaluation.autoAddToAllSprints && evaluation.autoSyncKey) {
+          for (let i = 0; i < next.sprints.length; i += 1) {
+            for (let j = 0; j < next.sprints[i].evaluations.length; j += 1) {
+              if (i === selected.sprintIndex && j === selected.evaluationIndex) continue;
+              const item = next.sprints[i].evaluations[j];
+              if (item.autoSyncKey === evaluation.autoSyncKey) {
+                item[field] = deepClone(evaluation[field]);
+              }
+            }
+          }
+        }
+      }
+      return next;
+    });
+  };
+
+  const validateBeforeSave = () => {
+    if (!template.name.trim() || !template.description.trim() || !template.term.trim()) {
+      return 'Template name, description and term are required.';
+    }
+    if (!template.projectStartDate) {
+      return 'Project start date is required.';
+    }
+    if (!template.sprints.length) return 'At least one sprint is required.';
+    if (projectTotalWeight !== 100) {
+      return `Project total deliverable weight must be exactly 100% (current: ${projectTotalWeight}%).`;
+    }
+    for (const sprint of template.sprints) {
+      if (!Array.isArray(sprint.deliverables)) return 'Each sprint must include deliverables.';
+      if (!Array.isArray(sprint.evaluations) || sprint.evaluations.length === 0) {
+        return 'Each sprint must include at least one evaluation.';
+      }
+      const evaluationTotal = sprint.evaluations.reduce(
+        (sum, e) => sum + (Number(e.weight) || 0),
+        0
+      );
+      if (evaluationTotal !== 100) {
+        return `Sprint ${sprint.sprintNo} evaluation weights must total exactly 100% (current: ${evaluationTotal}%).`;
+      }
+      const deliverableNames = new Set();
+      for (const deliverable of sprint.deliverables) {
+        const name = normalizeText(deliverable.title);
+        if (!name) return `Sprint ${sprint.sprintNo} has a deliverable with empty title.`;
+        if (deliverableNames.has(name)) {
+          return `Sprint ${sprint.sprintNo} cannot have duplicate deliverable titles.`;
+        }
+        deliverableNames.add(name);
+
+        const rubricNames = new Set();
+        for (const rubric of deliverable.rubrics || []) {
+          const rubricName = normalizeText(rubric.title);
+          if (!rubricName) return `Sprint ${sprint.sprintNo} deliverable rubric title cannot be empty.`;
+          if (rubricNames.has(rubricName)) {
+            return `Sprint ${sprint.sprintNo} deliverable "${deliverable.title}" has duplicate rubric titles.`;
+          }
+          rubricNames.add(rubricName);
+        }
+      }
+
+      const evaluationNames = new Set();
+      for (const evaluation of sprint.evaluations) {
+        const name = normalizeText(evaluation.title);
+        if (!name) return `Sprint ${sprint.sprintNo} has an evaluation with empty title.`;
+        if (evaluationNames.has(name)) {
+          return `Sprint ${sprint.sprintNo} cannot have duplicate evaluation titles.`;
+        }
+        evaluationNames.add(name);
+
+        const rubricNames = new Set();
+        for (const rubric of evaluation.rubrics || []) {
+          const rubricName = normalizeText(rubric.title);
+          if (!rubricName) return `Sprint ${sprint.sprintNo} evaluation rubric title cannot be empty.`;
+          if (rubricNames.has(rubricName)) {
+            return `Sprint ${sprint.sprintNo} evaluation "${evaluation.title}" has duplicate rubric titles.`;
+          }
+          rubricNames.add(rubricName);
+        }
+      }
+
+      const deliverableTotal = sprint.deliverables.reduce(
+        (sum, d) => sum + (Number(d.weight) || 0),
+        0
+      );
+    }
+    return '';
+  };
+
+  const saveTemplate = async () => {
+    const validationError = validateBeforeSave();
+    if (validationError) {
+      setStatus({ type: 'error', message: validationError });
+      return;
+    }
+    setSaving(true);
+    setStatus({ type: '', message: '' });
+    try {
+      const res = await createProjectTemplate(stripUiOnlyFields(template));
+      setStatus({
+        type: 'success',
+        message: `Template saved successfully (ID: ${res?.data?.templateId ?? 'n/a'})`,
+      });
+    } catch (err) {
+      setStatus({ type: 'error', message: err.message || 'Failed to save template.' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const selectedNode = (() => {
+    if (selected.type === 'sprint') return template.sprints[selected.sprintIndex];
+    if (selected.type === 'deliverable') {
+      return template.sprints[selected.sprintIndex]?.deliverables?.[selected.deliverableIndex];
+    }
+    if (selected.type === 'sprintEvaluation') {
+      return template.sprints[selected.sprintIndex]?.evaluations?.[selected.evaluationIndex];
+    }
+    return template;
+  })();
+  const customDeliverableTypes = Array.from(new Set(
+    template.sprints
+      .flatMap((sprint) => sprint.deliverables || [])
+      .map((deliverable) => (deliverable.type || '').trim())
+      .filter((type) => type && !DELIVERABLE_BASE_TYPES.includes(type))
+  ));
+  const allDeliverableTypeOptions = [...DELIVERABLE_BASE_TYPES, ...customDeliverableTypes];
+  const projectTotalWeight = template.sprints.reduce(
+    (sum, sprint) => sum + (sprint.deliverables || []).reduce((s, d) => s + (Number(d.weight) || 0), 0),
+    0
+  );
+
+  return (
+    <div className="template-builder-page">
+      <div className="template-builder-header">
+        <h1>Coordinator Template Builder</h1>
+        <button className="template-btn" onClick={saveTemplate} disabled={saving}>
+          {saving ? 'Saving...' : 'Save Template'}
+        </button>
+      </div>
+
+      {status.message && (
+        <div className={`template-status ${status.type === 'error' ? 'is-error' : 'is-success'}`}>
+          {status.message}
+        </div>
+      )}
+
+      <div className="template-builder-grid">
+        <aside className="template-tree">
+          <div className="template-tree-header">
+            <strong>Template Tree</strong>
+          </div>
+          <button
+            className={`template-node ${selected.type === 'template' ? 'active' : ''}`}
+            onClick={() => setSelected({ type: 'template' })}
+          >
+            Template Root (Project Total: {projectTotalWeight}%)
+          </button>
+          {template.sprints.map((sprint, sprintIndex) => (
+            <div className="template-tree-group" key={`sprint-${sprintIndex}`}>
+              <div className="node-row">
+                <button
+                  className={`template-node ${selected.type === 'sprint' && selected.sprintIndex === sprintIndex ? 'active' : ''}`}
+                  onClick={() => setSelected({ type: 'sprint', sprintIndex })}
+                >
+                  Sprint {sprint.sprintNo}: {sprint.title || 'Untitled'} (D: {(sprint.deliverables || []).reduce((sum, d) => sum + (Number(d.weight) || 0), 0)}% / E: {(sprint.evaluations || []).reduce((sum, e) => sum + (Number(e.weight) || 0), 0)}%)
+                </button>
+                <button className="delete-node-btn" onClick={() => removeSprint(sprintIndex)} title="Delete sprint">✕</button>
+              </div>
+              {sprint.evaluations.map((evaluation, evaluationIndex) => (
+                <div key={`ev-${sprintIndex}-${evaluationIndex}`} className="template-subtree">
+                  <div className="node-row">
+                    <button
+                      className={`template-node child ${selected.type === 'sprintEvaluation' && selected.sprintIndex === sprintIndex && selected.evaluationIndex === evaluationIndex ? 'active' : ''}`}
+                      onClick={() => setSelected({ type: 'sprintEvaluation', sprintIndex, evaluationIndex })}
+                    >
+                      Evaluation: {evaluation.title || 'Untitled'} ({Number(evaluation.weight) || 0}%)
+                    </button>
+                    <button
+                      className="delete-node-btn"
+                      onClick={() => removeSprintEvaluation(sprintIndex, evaluationIndex)}
+                      title="Delete evaluation"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+              ))}
+              <div className="template-subtree">
+                <div className="template-inline-actions">
+                  <button className="template-btn add-uniform" onClick={() => addSprintEvaluation(sprintIndex)}>
+                    + Evaluation
+                  </button>
+                  <button
+                    className="template-btn add-uniform"
+                    onClick={() => pasteEvaluation(sprintIndex)}
+                    disabled={!clipboard.evaluation}
+                  >
+                    Paste Evaluation
+                  </button>
+                </div>
+              </div>
+
+              {sprint.deliverables.map((deliverable, deliverableIndex) => (
+                <div key={`del-${sprintIndex}-${deliverableIndex}`} className="template-subtree">
+                  <div className="node-row">
+                    <button
+                      className={`template-node child ${selected.type === 'deliverable' && selected.sprintIndex === sprintIndex && selected.deliverableIndex === deliverableIndex ? 'active' : ''}`}
+                      onClick={() => setSelected({ type: 'deliverable', sprintIndex, deliverableIndex })}
+                    >
+                      Deliverable: {deliverable.title || 'Untitled'} ({Number(deliverable.weight) || 0}%)
+                    </button>
+                    <button
+                      className="delete-node-btn"
+                      onClick={() => removeDeliverable(sprintIndex, deliverableIndex)}
+                      title="Delete deliverable"
+                    >
+                      ✕
+                    </button>
+                  </div>
+                </div>
+              ))}
+              <div className="template-subtree">
+                <div className="template-inline-actions">
+                  <button className="template-btn add-uniform" onClick={() => addDeliverable(sprintIndex)}>
+                    + Deliverable
+                  </button>
+                  <button
+                    className="template-btn add-uniform"
+                    onClick={() => pasteDeliverable(sprintIndex)}
+                    disabled={!clipboard.deliverable}
+                  >
+                    Paste Deliverable
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+          <button className="template-btn add-sprint-bottom" onClick={addSprint}>+ Add Sprint</button>
+        </aside>
+
+        <section className="template-editor">
+          <h2>Editor</h2>
+          {selected.type === 'template' && (
+            <div className="template-form">
+              <label>Name<input value={template.name} onChange={(e) => updateTemplateField('name', e.target.value)} /></label>
+              <label className="field-full">Description<textarea value={template.description} onChange={(e) => updateTemplateField('description', e.target.value)} /></label>
+              <label>Term<input value={template.term} onChange={(e) => updateTemplateField('term', e.target.value)} /></label>
+              <AppDatePicker
+                label="Project Start Date"
+                value={template.projectStartDate}
+                onChange={(value) => updateTemplateField('projectStartDate', value)}
+              />
+            </div>
+          )}
+
+          {selected.type === 'sprint' && selectedNode && (
+            <div className="template-form">
+              <label>Sprint No<input type="number" value={selectedNode.sprintNo ?? ''} onChange={(e) => updateSelectedNode('sprintNo', Number(e.target.value))} /></label>
+              <label>Title<input value={selectedNode.title ?? ''} onChange={(e) => updateSelectedNode('title', e.target.value)} /></label>
+              <AppDateRangePicker
+                className="field-full"
+                label="Sprint Date Range"
+                startDate={selectedNode.startDate ?? ''}
+                endDate={selectedNode.endDate ?? ''}
+                onChange={(start, end) => {
+                  updateSelectedNode('startDate', start);
+                  updateSelectedNode('endDate', end);
+                }}
+              />
+            </div>
+          )}
+
+          {selected.type === 'deliverable' && selectedNode && (
+            <div className="template-form">
+              <div className="field-full editor-toolbar">
+                <button
+                  className="template-btn"
+                  type="button"
+                  onClick={() => setClipboard((prev) => ({ ...prev, deliverable: deepClone(selectedNode) }))}
+                >
+                  Copy Deliverable
+                </button>
+                <button
+                  className="template-btn"
+                  type="button"
+                  onClick={() => pasteDeliverable(selected.sprintIndex)}
+                  disabled={!clipboard.deliverable}
+                >
+                  Paste Deliverable
+                </button>
+              </div>
+              <label>
+                Type
+                <div className="type-combobox">
+                  <input
+                    value={selectedNode.type ?? ''}
+                    onFocus={() => {
+                      setTypeQuery(selectedNode.type ?? '');
+                      setShowTypeMenu(true);
+                    }}
+                    onBlur={() => {
+                      window.setTimeout(() => setShowTypeMenu(false), 120);
+                    }}
+                    onChange={(e) => {
+                      updateSelectedNode('type', e.target.value);
+                      setTypeQuery(e.target.value);
+                      setShowTypeMenu(true);
+                    }}
+                    placeholder="Search or create custom type"
+                  />
+                  {showTypeMenu && (
+                    <div className="type-combobox-menu">
+                      {allDeliverableTypeOptions.map((option) => (
+                        <button
+                          key={option}
+                          type="button"
+                          className="type-combobox-item"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => {
+                            updateSelectedNode('type', option);
+                            setTypeQuery(option);
+                            setShowTypeMenu(false);
+                          }}
+                        >
+                          {option}
+                        </button>
+                      ))}
+                      {!!normalizeText(typeQuery) && !allDeliverableTypeOptions.some((option) => normalizeText(option) === normalizeText(typeQuery)) && (
+                        <button
+                          type="button"
+                          className="type-combobox-item create"
+                          onMouseDown={(e) => e.preventDefault()}
+                          onClick={() => {
+                            updateSelectedNode('type', typeQuery.trim());
+                            setShowTypeMenu(false);
+                          }}
+                        >
+                          Use custom: "{typeQuery.trim()}"
+                        </button>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </label>
+              <label>Title<input value={selectedNode.title ?? ''} onChange={(e) => updateSelectedNode('title', e.target.value)} /></label>
+              <label className="field-full">Description<textarea value={selectedNode.description ?? ''} onChange={(e) => updateSelectedNode('description', e.target.value)} /></label>
+              <label>Weight<input type="number" value={selectedNode.weight ?? 0} onChange={(e) => updateSelectedNode('weight', Number(e.target.value))} /></label>
+              {!DELIVERABLE_BASE_TYPES.includes(selectedNode.type) && (
+                <label className="checkbox-row">
+                  <span>File upload deliverable</span>
+                  <input
+                    type="checkbox"
+                    checked={!!selectedNode.fileUploadDeliverable}
+                    onChange={(e) => updateSelectedNode('fileUploadDeliverable', e.target.checked)}
+                  />
+                </label>
+              )}
+              <label className="checkbox-row">
+                <span>Auto add to all sprints</span>
+                <input
+                  type="checkbox"
+                  checked={!!selectedNode.autoAddToAllSprints}
+                  onChange={(e) => updateSelectedNode('autoAddToAllSprints', e.target.checked)}
+                />
+              </label>
+              <div className="editor-subsection field-full">
+                <div className="editor-subsection-header">
+                  <strong>Rubrics</strong>
+                  <div className="template-inline-actions">
+                    <button
+                      className="template-btn add-uniform"
+                      onClick={() => addDeliverableRubric(selected.sprintIndex, selected.deliverableIndex)}
+                      type="button"
+                    >
+                      + Add Rubric
+                    </button>
+                    <button
+                      className="template-btn add-uniform"
+                      type="button"
+                      onClick={() => setClipboard((prev) => ({ ...prev, rubrics: deepClone(selectedNode.rubrics || []) }))}
+                    >
+                      Copy Rubrics
+                    </button>
+                    <button
+                      className="template-btn add-uniform"
+                      type="button"
+                      onClick={() => pasteDeliverableRubrics(selected.sprintIndex, selected.deliverableIndex)}
+                      disabled={!clipboard.rubrics}
+                    >
+                      Paste Rubrics
+                    </button>
+                  </div>
+                </div>
+                <div className="rubric-inline-list">
+                  {(selectedNode.rubrics || []).map((rubric, rubricIndex) => (
+                    <div className="rubric-inline-row" key={`d-editor-rubric-${rubricIndex}`}>
+                      <label>
+                        Title
+                        <input
+                          value={rubric.title ?? ''}
+                          onChange={(e) =>
+                            updateDeliverableRubricField(
+                              selected.sprintIndex,
+                              selected.deliverableIndex,
+                              rubricIndex,
+                              'title',
+                              e.target.value
+                            )
+                          }
+                        />
+                      </label>
+                      <label>
+                        Criteria Type
+                        <select
+                          value={rubric.criteriaType ?? 'SOFT'}
+                          onChange={(e) =>
+                            updateDeliverableRubricField(
+                              selected.sprintIndex,
+                              selected.deliverableIndex,
+                              rubricIndex,
+                              'criteriaType',
+                              e.target.value
+                            )
+                          }
+                        >
+                          {GRADING_TYPE_OPTIONS.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <button
+                        type="button"
+                        className="delete-node-btn"
+                        onClick={() =>
+                          removeDeliverableRubric(
+                            selected.sprintIndex,
+                            selected.deliverableIndex,
+                            rubricIndex
+                          )
+                        }
+                        title="Delete rubric"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {selected.type === 'sprintEvaluation' && selectedNode && (
+            <div className="template-form">
+              <div className="field-full editor-toolbar">
+                <button
+                  className="template-btn"
+                  type="button"
+                  onClick={() => setClipboard((prev) => ({ ...prev, evaluation: deepClone(selectedNode) }))}
+                >
+                  Copy Evaluation
+                </button>
+                <button
+                  className="template-btn"
+                  type="button"
+                  onClick={() => pasteEvaluation(selected.sprintIndex)}
+                  disabled={!clipboard.evaluation}
+                >
+                  Paste Evaluation
+                </button>
+              </div>
+              <label>Title<input value={selectedNode.title ?? ''} onChange={(e) => updateSelectedNode('title', e.target.value)} /></label>
+              <label>Weight<input type="number" value={selectedNode.weight ?? 0} onChange={(e) => updateSelectedNode('weight', Number(e.target.value))} /></label>
+              <label className="checkbox-row">
+                <span>Auto add to all sprints</span>
+                <input
+                  type="checkbox"
+                  checked={!!selectedNode.autoAddToAllSprints}
+                  onChange={(e) => updateSelectedNode('autoAddToAllSprints', e.target.checked)}
+                />
+              </label>
+              <div className="editor-subsection field-full">
+                <div className="editor-subsection-header">
+                  <strong>Rubrics</strong>
+                  <div className="template-inline-actions">
+                    <button
+                      className="template-btn add-uniform"
+                      onClick={() => addSprintEvalRubric(selected.sprintIndex, selected.evaluationIndex)}
+                      type="button"
+                    >
+                      + Add Rubric
+                    </button>
+                    <button
+                      className="template-btn add-uniform"
+                      type="button"
+                      onClick={() => setClipboard((prev) => ({ ...prev, rubrics: deepClone(selectedNode.rubrics || []) }))}
+                    >
+                      Copy Rubrics
+                    </button>
+                    <button
+                      className="template-btn add-uniform"
+                      type="button"
+                      onClick={() => pasteEvaluationRubrics(selected.sprintIndex, selected.evaluationIndex)}
+                      disabled={!clipboard.rubrics}
+                    >
+                      Paste Rubrics
+                    </button>
+                  </div>
+                </div>
+                <div className="rubric-inline-list">
+                  {(selectedNode.rubrics || []).map((rubric, rubricIndex) => (
+                    <div className="rubric-inline-row" key={`e-editor-rubric-${rubricIndex}`}>
+                      <label>
+                        Title
+                        <input
+                          value={rubric.title ?? ''}
+                          onChange={(e) =>
+                            updateSprintEvaluationRubricField(
+                              selected.sprintIndex,
+                              selected.evaluationIndex,
+                              rubricIndex,
+                              'title',
+                              e.target.value
+                            )
+                          }
+                        />
+                      </label>
+                      <label>
+                        Criteria Type
+                        <select
+                          value={rubric.criteriaType ?? 'SOFT'}
+                          onChange={(e) =>
+                            updateSprintEvaluationRubricField(
+                              selected.sprintIndex,
+                              selected.evaluationIndex,
+                              rubricIndex,
+                              'criteriaType',
+                              e.target.value
+                            )
+                          }
+                        >
+                          {GRADING_TYPE_OPTIONS.map((option) => (
+                            <option key={option} value={option}>{option}</option>
+                          ))}
+                        </select>
+                      </label>
+                      <button
+                        type="button"
+                        className="delete-node-btn"
+                        onClick={() =>
+                          removeSprintEvaluationRubric(
+                            selected.sprintIndex,
+                            selected.evaluationIndex,
+                            rubricIndex
+                          )
+                        }
+                        title="Delete rubric"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export default TemplateBuilder;

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -125,3 +125,10 @@ export function getGitHubAuthUrl() {
 export function getLogs(page = 0, size = 20) {
   return request(`/logs?page=${page}&size=${size}`);
 }
+
+export function createProjectTemplate(payload) {
+  return request('/project-templates', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}


### PR DESCRIPTION

Implement full relational project/template flows with coordinator template builder UI, project APIs, and project-level groupId persistence so templates can be instantiated and tracked end-to-end.

Made-with: Cursor