### PR TITLE
feat: implement score override storage and 4.0 recalculation logic #129

### DIFF
--- a/backend/src/main/java/com/seniorapp/controller/GradeController.java
+++ b/backend/src/main/java/com/seniorapp/controller/GradeController.java
@@ -37,4 +37,18 @@ public class GradeController {
                 .collect(Collectors.toList());
         return ResponseEntity.ok(response);
     }
+
+    /**
+     * Issue #129: Manual Score Override Endpoint
+     * This allows advisors to manually change a grade and triggers 4.0 recalculation.
+     */
+    @PatchMapping("/grades/{gradeId}/override")
+    public ResponseEntity<GradeResponse> overrideGrade(
+            @PathVariable Long gradeId,
+            @RequestParam Double manualScore,
+            @RequestParam String advisorName) {
+        
+        SubmissionGrade updatedGrade = gradeService.overrideGrade(gradeId, manualScore, advisorName);
+        return ResponseEntity.ok(new GradeResponse(updatedGrade));
+    }
 }

--- a/backend/src/main/java/com/seniorapp/entity/SubmissionGrade.java
+++ b/backend/src/main/java/com/seniorapp/entity/SubmissionGrade.java
@@ -1,6 +1,7 @@
 package com.seniorapp.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "submission_grades")
@@ -24,6 +25,23 @@ public class SubmissionGrade {
     @Column(nullable = false)
     private Double grade;
 
+    
+    @Column(name = "original_ai_score")
+    private Double originalAiScore;
+
+    @Column(name = "advisor_adjusted_score")
+    private Double advisorAdjustedScore;
+
+    @Column(name = "final_grade_4_0")
+    private Double finalGrade40;
+
+    @Column(name = "last_modified_by")
+    private String lastModifiedBy;
+
+    @Column(name = "last_modified_at")
+    private LocalDateTime lastModifiedAt;
+
+  
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 
@@ -38,4 +56,20 @@ public class SubmissionGrade {
 
     public Double getGrade() { return grade; }
     public void setGrade(Double grade) { this.grade = grade; }
+
+    // --- Added Getters and Setters for Issue #129 ---
+    public Double getOriginalAiScore() { return originalAiScore; }
+    public void setOriginalAiScore(Double originalAiScore) { this.originalAiScore = originalAiScore; }
+
+    public Double getAdvisorAdjustedScore() { return advisorAdjustedScore; }
+    public void setAdvisorAdjustedScore(Double advisorAdjustedScore) { this.advisorAdjustedScore = advisorAdjustedScore; }
+
+    public Double getFinalGrade40() { return finalGrade40; }
+    public void setFinalGrade40(Double finalGrade40) { this.finalGrade40 = finalGrade40; }
+
+    public String getLastModifiedBy() { return lastModifiedBy; }
+    public void setLastModifiedBy(String lastModifiedBy) { this.lastModifiedBy = lastModifiedBy; }
+
+    public LocalDateTime getLastModifiedAt() { return lastModifiedAt; }
+    public void setLastModifiedAt(LocalDateTime lastModifiedAt) { this.lastModifiedAt = lastModifiedAt; }
 }

--- a/backend/src/main/java/com/seniorapp/service/GradeService.java
+++ b/backend/src/main/java/com/seniorapp/service/GradeService.java
@@ -8,7 +8,9 @@ import com.seniorapp.repository.DeliverableSubmissionRepository;
 import com.seniorapp.repository.SubmissionGradeRepository;
 import com.seniorapp.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -42,7 +44,40 @@ public class GradeService {
         grade.setRubricId(request.getRubricId());
         grade.setGrade(request.getGrade());
         
+        // When first created, we can also set the original AI score if applicable
+        grade.setOriginalAiScore(request.getGrade());
+        
         return gradeRepository.save(grade);
+    }
+
+    
+    @Transactional
+    public SubmissionGrade overrideGrade(Long gradeId, Double newScore, String advisorName) {
+        // 1. Fetch existing grade
+        SubmissionGrade gradeRecord = gradeRepository.findById(gradeId)
+                .orElseThrow(() -> new IllegalArgumentException("Grade record not found with ID: " + gradeId));
+
+        // 2. Preserve original AI score if it hasn't been set yet
+        if (gradeRecord.getOriginalAiScore() == null) {
+            gradeRecord.setOriginalAiScore(gradeRecord.getGrade());
+        }
+
+        // 3. Store the manual adjustment
+        gradeRecord.setAdvisorAdjustedScore(newScore);
+        
+        // 4. Update the main grade field
+        gradeRecord.setGrade(newScore);
+
+        // 5. Automatic Recalculation to 4.0 scale
+        // Formula: (newScore / 100.0) * 4.0
+        double calculatedGpa = (newScore / 100.0) * 4.0;
+        gradeRecord.setFinalGrade40(calculatedGpa);
+
+        // 6. Audit traceability
+        gradeRecord.setLastModifiedBy(advisorName);
+        gradeRecord.setLastModifiedAt(LocalDateTime.now());
+
+        return gradeRepository.save(gradeRecord);
     }
 
     public List<SubmissionGrade> getGradesForSubmission(Long submissionId) {


### PR DESCRIPTION
Description:
This Pull Request implements the backend logic for handling manual score overrides by advisors and the automatic recalculation of the final grade on a 4.0 scale, as specified in Issue #129.

Key Changes:
- Database Schema Update: Added fields to the SubmissionGrade entity to store original_ai_score, advisor_adjusted_score, and final_grade_4_0.

- Audit Traceability: Integrated metadata fields (last_modified_by and last_modified_at) to track who made the override and when.

Grading Logic:

      - Implemented overrideGrade method in GradeService to preserve the original AI score during the first manual adjustment.

    - Added automatic conversion logic from a 100-point scale to a 4.0 scale.

     - API Enhancement: Added a new @PatchMapping endpoint in GradeController to allow manual grade overrides.

Acceptance Criteria Checklist:
- Store both original_ai_score and advisor_adjusted_score

- Automatically trigger recalculation of final 4.0 Assessment

- Save override metadata for audit traceability