### PR TITLE
Fix: #159 Create Project Screen UI Improvements

### DIFF
--- a/frontend/src/pages/CreateGroup.css
+++ b/frontend/src/pages/CreateGroup.css
@@ -86,15 +86,38 @@
 }
 
 .template-card {
-  border: 1px solid #e5e7eb;
+  border: 1.5px solid #e5e7eb;
   border-radius: 12px;
   padding: 16px;
   background: #f8faff;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 0.18s, box-shadow 0.18s, transform 0.12s;
+}
+
+.template-card:hover {
+  border-color: #818cf8;
+  box-shadow: 0 4px 16px rgba(99, 102, 241, 0.12);
+  transform: translateY(-2px);
 }
 
 .template-card.selected {
-  border-color: #4318ff;
-  box-shadow: 0 0 0 1px #4318ff inset;
+  border-color: #4f46e5;
+  background: #eef2ff;
+  box-shadow: 0 0 0 2px #4f46e5 inset;
+}
+
+.template-selected-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #4f46e5;
+  background: #e0e7ff;
+  border-radius: 20px;
+  padding: 2px 10px;
+  margin-bottom: 8px;
 }
 
 .template-card h4 {
@@ -123,7 +146,21 @@
 
 .template-loading,
 .template-empty {
-  color: #475467;
+  color: #64748b;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.create-group-form input:focus,
+.create-group-form select:focus {
+  border-color: #818cf8;
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.15);
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/pages/CreateGroup.jsx
+++ b/frontend/src/pages/CreateGroup.jsx
@@ -26,14 +26,18 @@ const CreateGroup = () => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    
-    if (!groupName || !projectId) {
-      setError("Please fill in all fields.");
+
+    if (!groupName.trim()) {
+      setError('Please enter a group name.');
+      return;
+    }
+    if (!projectId) {
+      setError('Please select a project template.');
       return;
     }
 
     setError('');
-    console.log("Submitting Group Data:", { groupName, projectId });
+    console.log('Submitting Group Data:', { groupName, projectId });
     alert(`Group "${groupName}" has been created successfully!`);
   };
 
@@ -86,7 +90,15 @@ const CreateGroup = () => {
             <p>Review sprint count and deliverables before creating a group.</p>
           </div>
 
-          {loadingTemplates && <div className="template-loading">Loading templates...</div>}
+          {loadingTemplates && (
+            <div className="template-loading">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5"
+                style={{ animation: 'spin 1s linear infinite', verticalAlign: 'middle', marginRight: 8 }}>
+                <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+              </svg>
+              Loading templates…
+            </div>
+          )}
 
           {!loadingTemplates && templates.length === 0 && (
             <div className="template-empty">No project templates are currently available.</div>
@@ -97,8 +109,16 @@ const CreateGroup = () => {
               {templates.map((template) => (
                 <article
                   key={template.projectId}
-                  className={`template-card${projectId === template.projectId ? ' selected' : ''}`}
+                  className={`template-card${projectId === String(template.projectId) ? ' selected' : ''}`}
+                  onClick={() => setProjectId(String(template.projectId))}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => e.key === 'Enter' && setProjectId(String(template.projectId))}
+                  aria-pressed={projectId === String(template.projectId)}
                 >
+                  {projectId === String(template.projectId) && (
+                    <div className="template-selected-badge">✓ Selected</div>
+                  )}
                   <h4>{template.name}</h4>
                   <p className="template-meta">Sprint count: {template.sprintCount}</p>
                   <div className="template-deliverables-title">Deliverables</div>


### PR DESCRIPTION
## Summary
This Pull Request addresses Issue #159 by polishing the "Create Group / Template Selection" screen. The goal of this PR is to reduce user friction by making the template selection process more interactive, visually clear, and accessible.

## Work Completed
- **Interactive Template Cards (`CreateGroup.jsx` & `CreateGroup.css`):**
  - Made entire template cards clickable, allowing users to select a template by clicking the card instead of relying solely on the dropdown menu. The dropdown menu and cards sync perfectly in both directions.
  - Added a prominent `✓ Selected` badge, border highlights, and background tinting to clearly distinguish the currently active template.
  - Improved accessibility (a11y) by adding `role="button"`, `tabIndex={0}`, and `onKeyDown` handlers so cards can be navigated and selected via keyboard.
- **State Management & Feedback:**
  - Implemented an animated SVG loading spinner during the initial fetch of project templates.
  - Added focus rings (`box-shadow`) to input elements and select dropdowns to improve accessibility and modern visual standards.

## Testing & Verification
- **Interaction Testing:**
  - Verified bidirectional sync: Selecting a card updates the hidden/visible `<select>` element, and choosing from the `<select>` element updates the highlighted card.
  - Keyboard Navigation: Verified that users can tab through the template cards and press `Enter` to select them.
- **State Verification:**
  - Tested loading states by simulating API latency; the new SVG spinner appears correctly before templates load.
  - Tested form submission preventing progression if no template is selected, validating that visual cues match the required state.
